### PR TITLE
context when failing to read files on startup

### DIFF
--- a/publish-mqtt/src/main.rs
+++ b/publish-mqtt/src/main.rs
@@ -26,7 +26,7 @@ const SENSOR_NAMES_FILENAME: &str = "sensor_names.conf";
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    dotenv::dotenv()?;
+    dotenv::dotenv().context("reading .env")?;
     pretty_env_logger::init();
     color_backtrace::install();
 
@@ -218,7 +218,8 @@ async fn run_sensor_system(
     mut homie: HomieDevice,
     bt_session: &MijiaSession,
 ) -> Result<(), anyhow::Error> {
-    let sensor_names = hashmap_from_file(SENSOR_NAMES_FILENAME)?;
+    let sensor_names = hashmap_from_file(SENSOR_NAMES_FILENAME)
+        .context(format!("reading {}", SENSOR_NAMES_FILENAME))?;
 
     homie
         .ready()


### PR DESCRIPTION
with missing .env, this generates:
```
$ ./publish-mqtt 
Error: reading .env

Caused by:
    0: path not found
    1: path not found
```

Not fantastic, but at least debuggable. We can work on reporting backtraces later.

<img src="https://media.giphy.com/media/VIQfHC9jAZbt6ojTdo/giphy-downsized.gif"/>