### PR TITLE
move subscription retrying into connect_and_subscribe_sensor(); simplify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "backoff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721c249ab59cbc483ad4294c9ee2671835c1e43e9ffc277e6b4ecfef733cfdc5"
+dependencies = [
+ "futures-core",
+ "instant",
+ "pin-project",
+ "rand",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,6 +439,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63312a18f7ea8760cdd0a7c5aac1a619752a246b833545e3e36d1f81f7cd9e66"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,6 +776,7 @@ name = "publish-mqtt"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "backoff",
  "color-backtrace",
  "dotenv",
  "futures",

--- a/mijia/src/lib.rs
+++ b/mijia/src/lib.rs
@@ -16,7 +16,7 @@ const SENSOR_READING_CHARACTERISTIC_PATH: &str = "/service0021/char0035";
 const CONNECTION_INTERVAL_CHARACTERISTIC_PATH: &str = "/service0021/char0045";
 /// 500 in little-endian
 const CONNECTION_INTERVAL_500_MS: [u8; 3] = [0xF4, 0x01, 0x00];
-pub const DBUS_METHOD_CALL_TIMEOUT: Duration = Duration::from_secs(30);
+const DBUS_METHOD_CALL_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Clone, Debug)]
 pub struct SensorProps {

--- a/mijia/src/lib.rs
+++ b/mijia/src/lib.rs
@@ -16,7 +16,7 @@ const SENSOR_READING_CHARACTERISTIC_PATH: &str = "/service0021/char0035";
 const CONNECTION_INTERVAL_CHARACTERISTIC_PATH: &str = "/service0021/char0045";
 /// 500 in little-endian
 const CONNECTION_INTERVAL_500_MS: [u8; 3] = [0xF4, 0x01, 0x00];
-const DBUS_METHOD_CALL_TIMEOUT: Duration = Duration::from_secs(30);
+pub const DBUS_METHOD_CALL_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Clone, Debug)]
 pub struct SensorProps {

--- a/publish-mqtt/Cargo.toml
+++ b/publish-mqtt/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/alsuren/mijia-homie/"
 
 [dependencies]
 anyhow = "1.0.32"
+backoff = { version = "0.2.1", features = ["tokio"] }
 color-backtrace = "0.4.2"
 dotenv = "0.15.0"
 futures = "0.3.5"

--- a/publish-mqtt/src/main.rs
+++ b/publish-mqtt/src/main.rs
@@ -404,17 +404,17 @@ async fn connect_sensor_at_idx(
     let result = connect_and_subscribe_sensor_or_disconnect(session, &sensor.id).await;
     let mut state = state.lock().await;
     match result {
+        Ok(()) => {
+            println!("Connected to {} and started notifications", sensor.name);
+            sensor.mark_connected(&mut state.homie).await?;
+            sensor.last_update_timestamp = Instant::now();
+        }
         Err(e) => {
             println!(
                 "Failed to connect to {} (now {:?}): {:?}",
                 sensor.name, sensor.connection_status, e
             );
             sensor.connection_status = ConnectionStatus::Disconnected;
-        }
-        Ok(()) => {
-            println!("Connected to {} and started notifications", sensor.name);
-            sensor.mark_connected(&mut state.homie).await?;
-            sensor.last_update_timestamp = Instant::now();
         }
     }
     state.sensors[idx] = sensor;

--- a/publish-mqtt/src/main.rs
+++ b/publish-mqtt/src/main.rs
@@ -220,10 +220,14 @@ impl Sensor {
 }
 
 trait SensorStore {
+    fn get_by_id(&self, id: &DeviceId) -> Option<&Sensor>;
     fn get_mut_by_id(&mut self, id: &DeviceId) -> Option<&mut Sensor>;
 }
 
 impl SensorStore for Vec<Sensor> {
+    fn get_by_id(&self, id: &DeviceId) -> Option<&Sensor> {
+        self.iter().find(|s| &s.id == id)
+    }
     fn get_mut_by_id(&mut self, id: &DeviceId) -> Option<&mut Sensor> {
         self.iter_mut().find(|s| &s.id == id)
     }


### PR DESCRIPTION
This allows us to delete the SubscribingFailedOnce state, because it is folded into Connecting.

There are also some meanderings about using id rather than idx to identify sensors. Once we stop caring about the ConnectionStatus while connecting. Mijia only cares about the id, so if we can also only care about the id then we are only holding a single piece of state across the connection attempt, which feels quite elegant.

