### PR TITLE
Iterate over all sensors each time through connection loop

### DIFF
--- a/publish-mqtt/src/main.rs
+++ b/publish-mqtt/src/main.rs
@@ -314,7 +314,7 @@ async fn bluetooth_connection_loop(
                 .collect();
             for id in ids {
                 let sensor_status = state.lock().await.sensors.get_by_id(&id).map(|sensor| {
-                    println!("State of {} is {:?}", sensor.name, sensor.connection_status);
+                    log::trace!("State of {} is {:?}", sensor.name, sensor.connection_status);
                     sensor.connection_status
                 });
                 if let Some(connection_status) = sensor_status {

--- a/publish-mqtt/src/main.rs
+++ b/publish-mqtt/src/main.rs
@@ -308,7 +308,7 @@ async fn bluetooth_connection_loop(
         // Check the state of a single sensor and act on it if appropriate.
         {
             // TODO: Iterate over sensors here rather than storing next_idx in SensorState.
-            action_next_sensor(state.clone(), session.clone())
+            action_next_sensor(state.clone(), session)
                 .await
                 .with_context(|| std::line!().to_string())?;
         }

--- a/publish-mqtt/src/main.rs
+++ b/publish-mqtt/src/main.rs
@@ -293,15 +293,19 @@ async fn bluetooth_connection_loop(
         {
             let ids: Vec<DeviceId> = state.lock().await.sensors.keys().cloned().collect();
             for id in ids {
-                let sensor_status = state.lock().await.sensors.get(&id).map(|sensor| {
-                    log::trace!("State of {} is {:?}", sensor.name, sensor.connection_status);
-                    sensor.connection_status
-                });
-                if let Some(connection_status) = sensor_status {
-                    action_sensor(state.clone(), session, id, connection_status)
-                        .await
-                        .with_context(|| std::line!().to_string())?;
-                }
+                let connection_status = state
+                    .lock()
+                    .await
+                    .sensors
+                    .get(&id)
+                    .map(|sensor| {
+                        log::trace!("State of {} is {:?}", sensor.name, sensor.connection_status);
+                        sensor.connection_status
+                    })
+                    .expect("sensors cannot be deleted");
+                action_sensor(state.clone(), session, id, connection_status)
+                    .await
+                    .with_context(|| std::line!().to_string())?;
             }
         }
         time::delay_for(CONNECT_INTERVAL).await;

--- a/publish-mqtt/src/main.rs
+++ b/publish-mqtt/src/main.rs
@@ -326,12 +326,21 @@ async fn action_next_sensor(
     state: Arc<Mutex<SensorState>>,
     session: &MijiaSession,
 ) -> Result<(), anyhow::Error> {
-    let (name, status, id) = match next_actionable_sensor(state.clone()).await {
-        Some(values) => values,
-        None => return Ok(()),
-    };
+    match next_actionable_sensor(state.clone()).await {
+        Some((name, status, id)) => {
+            println!("State of {} is {:?}", name, status);
+            action_sensor(state, session, id, status).await
+        }
+        None => Ok(()),
+    }
+}
 
-    println!("State of {} is {:?}", name, status);
+async fn action_sensor(
+    state: Arc<Mutex<SensorState>>,
+    session: &MijiaSession,
+    id: DeviceId,
+    status: ConnectionStatus,
+) -> Result<(), anyhow::Error> {
     match status {
         ConnectionStatus::Connecting { reserved_until } if reserved_until > Instant::now() => {
             Ok(())


### PR DESCRIPTION
Store sensors in a HashMap rather than a Vec to avoid the need for the `SensorStore` methods, and then iterate over them all each time through the connection loop by cloning the set of IDs which key the map.