### PR TITLE
Minor cleanups to homie-device crate

### DIFF
--- a/homie-device/examples/lifecycle.rs
+++ b/homie-device/examples/lifecycle.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let mqttoptions = MqttOptions::new("homie_example", "test.mosquitto.org", 1883);
 
     let (mut homie, homie_handle) =
-        HomieDevice::builder("homie/example", "Homie example", mqttoptions)
+        HomieDevice::builder("homie/example_lifecycle", "Homie lifecycle example", mqttoptions)
             .spawn()
             .await?;
 

--- a/homie-device/examples/light.rs
+++ b/homie-device/examples/light.rs
@@ -7,7 +7,8 @@ async fn main() -> Result<(), SpawnError> {
 
     let mqttoptions = MqttOptions::new("homie_example", "test.mosquitto.org", 1883);
 
-    let mut builder = HomieDevice::builder("homie/example", "Homie light example", mqttoptions);
+    let mut builder =
+        HomieDevice::builder("homie/example_light", "Homie light example", mqttoptions);
     builder.set_update_callback(|node_id, property_id, value| async move {
         println!("{}/{} is now {}", node_id, property_id, value);
         Some(value)

--- a/homie-device/examples/sensor.rs
+++ b/homie-device/examples/sensor.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let mqttoptions = MqttOptions::new("homie_example", "test.mosquitto.org", 1883);
 
     let (mut homie, homie_handle) =
-        HomieDevice::builder("homie/example", "Homie sensor example", mqttoptions)
+        HomieDevice::builder("homie/example_sensor", "Homie sensor example", mqttoptions)
             .spawn()
             .await?;
 

--- a/homie-device/src/lib.rs
+++ b/homie-device/src/lib.rs
@@ -21,6 +21,9 @@ use thiserror::Error;
 use tokio::task::{self, JoinError, JoinHandle};
 use tokio::time::delay_for;
 
+mod types;
+pub use crate::types::{Datatype, Node, Property};
+
 const HOMIE_VERSION: &str = "4.0";
 const HOMIE_IMPLEMENTATION: &str = "homie-rs";
 const DEFAULT_FIRMWARE_NAME: &str = env!("CARGO_PKG_NAME");
@@ -39,105 +42,6 @@ pub enum SpawnError {
     Join(#[from] JoinError),
     #[error("Internal error: {0}")]
     Internal(&'static str),
-}
-
-/// The data type for a Homie property.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum Datatype {
-    Integer,
-    Float,
-    Boolean,
-    String,
-    Enum,
-    Color,
-}
-
-impl Into<Vec<u8>> for Datatype {
-    fn into(self) -> Vec<u8> {
-        match self {
-            Self::Integer => "integer",
-            Self::Float => "float",
-            Self::Boolean => "boolean",
-            Self::String => "string",
-            Self::Enum => "enum",
-            Self::Color => "color",
-        }
-        .into()
-    }
-}
-
-/// A [property](https://homieiot.github.io/specification/#properties) of a Homie node.
-#[derive(Clone, Debug)]
-pub struct Property {
-    id: String,
-    name: String,
-    datatype: Datatype,
-    settable: bool,
-    unit: Option<String>,
-    format: Option<String>,
-}
-
-impl Property {
-    /// Create a new property with the given attributes.
-    ///
-    /// # Arguments
-    /// * `id`: The topic ID for the property. This must be unique per node, and follow the Homie
-    ///   [ID format](https://homieiot.github.io/specification/#topic-ids).
-    /// * `name`: The human-readable name of the property.
-    /// * `datatype`: The data type of the property.
-    /// * `settable`: Whether the property can be set by the Homie controller. This should be true
-    ///   for properties like the brightness or power state of a light, and false for things like
-    ///   the temperature reading of a sensor.
-    /// * `unit`: The unit for the property, if any. This may be one of the
-    ///   [recommended units](https://homieiot.github.io/specification/#property-attributes), or
-    ///   any other custom unit.
-    /// * `format`: The format for the property, if any. This must be specified if the datatype is
-    ///   `Enum` or `Color`, and may be specified if the datatype is `Integer` or `Float`.
-    pub fn new(
-        id: &str,
-        name: &str,
-        datatype: Datatype,
-        settable: bool,
-        unit: Option<&str>,
-        format: Option<&str>,
-    ) -> Property {
-        Property {
-            id: id.to_owned(),
-            name: name.to_owned(),
-            datatype,
-            settable,
-            unit: unit.map(|s| s.to_owned()),
-            format: format.map(|s| s.to_owned()),
-        }
-    }
-}
-
-/// A [node](https://homieiot.github.io/specification/#nodes) of a Homie device.
-#[derive(Clone, Debug)]
-pub struct Node {
-    id: String,
-    name: String,
-    node_type: String,
-    properties: Vec<Property>,
-}
-
-impl Node {
-    /// Create a new node with the given attributes.
-    ///
-    /// # Arguments
-    /// * `id`: The topic ID for the node. This must be unique per device, and follow the Homie
-    ///   [ID format](https://homieiot.github.io/specification/#topic-ids).
-    /// * `name`: The human-readable name of the node.
-    /// * `type`: The type of the node. This is an arbitrary string.
-    /// * `property`: The properties of the node. There should be at least one.
-    pub fn new(id: &str, name: &str, node_type: &str, properties: Vec<Property>) -> Node {
-        Node {
-            id: id.to_owned(),
-            name: name.to_owned(),
-            node_type: node_type.to_owned(),
-            properties,
-        }
-    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/homie-device/src/types.rs
+++ b/homie-device/src/types.rs
@@ -1,0 +1,100 @@
+use std::fmt::Debug;
+
+/// The data type for a Homie property.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Datatype {
+    Integer,
+    Float,
+    Boolean,
+    String,
+    Enum,
+    Color,
+}
+
+impl Into<Vec<u8>> for Datatype {
+    fn into(self) -> Vec<u8> {
+        match self {
+            Self::Integer => "integer",
+            Self::Float => "float",
+            Self::Boolean => "boolean",
+            Self::String => "string",
+            Self::Enum => "enum",
+            Self::Color => "color",
+        }
+        .into()
+    }
+}
+
+/// A [property](https://homieiot.github.io/specification/#properties) of a Homie node.
+#[derive(Clone, Debug)]
+pub struct Property {
+    pub id: String,
+    pub name: String,
+    pub datatype: Datatype,
+    pub settable: bool,
+    pub unit: Option<String>,
+    pub format: Option<String>,
+}
+
+impl Property {
+    /// Create a new property with the given attributes.
+    ///
+    /// # Arguments
+    /// * `id`: The topic ID for the property. This must be unique per node, and follow the Homie
+    ///   [ID format](https://homieiot.github.io/specification/#topic-ids).
+    /// * `name`: The human-readable name of the property.
+    /// * `datatype`: The data type of the property.
+    /// * `settable`: Whether the property can be set by the Homie controller. This should be true
+    ///   for properties like the brightness or power state of a light, and false for things like
+    ///   the temperature reading of a sensor.
+    /// * `unit`: The unit for the property, if any. This may be one of the
+    ///   [recommended units](https://homieiot.github.io/specification/#property-attributes), or
+    ///   any other custom unit.
+    /// * `format`: The format for the property, if any. This must be specified if the datatype is
+    ///   `Enum` or `Color`, and may be specified if the datatype is `Integer` or `Float`.
+    pub fn new(
+        id: &str,
+        name: &str,
+        datatype: Datatype,
+        settable: bool,
+        unit: Option<&str>,
+        format: Option<&str>,
+    ) -> Property {
+        Property {
+            id: id.to_owned(),
+            name: name.to_owned(),
+            datatype,
+            settable,
+            unit: unit.map(|s| s.to_owned()),
+            format: format.map(|s| s.to_owned()),
+        }
+    }
+}
+
+/// A [node](https://homieiot.github.io/specification/#nodes) of a Homie device.
+#[derive(Clone, Debug)]
+pub struct Node {
+    pub id: String,
+    pub name: String,
+    pub node_type: String,
+    pub properties: Vec<Property>,
+}
+
+impl Node {
+    /// Create a new node with the given attributes.
+    ///
+    /// # Arguments
+    /// * `id`: The topic ID for the node. This must be unique per device, and follow the Homie
+    ///   [ID format](https://homieiot.github.io/specification/#topic-ids).
+    /// * `name`: The human-readable name of the node.
+    /// * `type`: The type of the node. This is an arbitrary string.
+    /// * `property`: The properties of the node. There should be at least one.
+    pub fn new(id: &str, name: &str, node_type: &str, properties: Vec<Property>) -> Node {
+        Node {
+            id: id.to_owned(),
+            name: name.to_owned(),
+            node_type: node_type.to_owned(),
+            properties,
+        }
+    }
+}


### PR DESCRIPTION
Split data structs out to a separate module, and use a different device ID for each example.