### PR TITLE
Prepare new version of homie-device crate for release.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "homie-device"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-channel",
  "futures",

--- a/homie-device/Cargo.toml
+++ b/homie-device/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "homie-device"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Andrew Walbran <qwandor@google.com>", "David Laban <alsuren@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This version changes the API in an incompatible way, in that the error types of some functions have changed.