### PR TITLE
Don't quote $PROFILE_FLAG, because it might be empty.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -38,10 +38,12 @@ fi
 cargo install cross
 
 if [ "${EXAMPLE}" != "" ]; then
-    time cross build "$PROFILE_FLAG" --target $TARGET --example "$EXAMPLE"
+    # shellcheck disable=SC2086
+    time cross build $PROFILE_FLAG --target "$TARGET" --example "$EXAMPLE"
     time rsync --progress "target/$TARGET/$PROFILE/examples/$EXAMPLE" "$TARGET_SSH:$EXAMPLE"
 else
-    time cross build "$PROFILE_FLAG" --target $TARGET --bin mijia-homie
+    # shellcheck disable=SC2086
+    time cross build $PROFILE_FLAG --target "$TARGET" --bin mijia-homie
     time rsync --progress "target/$TARGET/$PROFILE/mijia-homie" "$TARGET_SSH:mijia-homie"
 fi
 


### PR DESCRIPTION
This was breaking run.sh for the debug profile.

This fixes a bug introduced by #51 commit 0b3bf5e0a3963413fa341d93bb7b57f6b0343ca3.