### PR TITLE
Add job to create a draft release when a mijia-homie-* tag is pushed.

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -3,6 +3,7 @@ name: Package
 on:
   push:
     branches: [master]
+    tags: ['mijia-homie-*']
 
 env:
   CARGO_TERM_COLOR: always
@@ -80,3 +81,37 @@ jobs:
         with:
           name: debian-packages
           path: target/${{ matrix.target }}/debian/
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/mijia-homie-')
+    steps:
+      - name: Download packages
+        uses: actions/download-artifact@v2
+        with:
+          name: debian-packages
+      - name: Get version
+        id: version
+        uses: frabert/replace-string-action@v1.2
+        with:
+          string: ${{ github.ref }}
+          pattern: 'refs/tags/mijia-homie-(.+)'
+          replace-with: '$1'
+      - name: Create draft release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions.
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: mijia-homie release ${{ steps.version.outputs.replaced }}
+          draft: true
+          prerelease: false
+      - name: Upload packages to release
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: '*.deb'
+          asset_content_type: application/vnd.debian.binary-package


### PR DESCRIPTION
Debian packages will be built as usual and uploaded to the release as assets. The release can be published manually once it has been checked.

This is the next step for #18.