### PR TITLE
Use all Bluetooth adapters rather than just hci0.

### DIFF
--- a/mijia-homie/src/main.rs
+++ b/mijia-homie/src/main.rs
@@ -1,4 +1,4 @@
-#![type_length_limit = "1129369"]
+#![type_length_limit = "1138969"]
 
 use backoff::{future::FutureOperation, ExponentialBackoff};
 use futures::stream::StreamExt;


### PR DESCRIPTION
This fixes #58 the bug on VIM3L, which for some reason has `hci1` rather than `hci0`.

Is there a better way to do this?