### PR TITLE
Prepare bluez-generated and mijia crates for publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bluez-generated"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "dbus",
 ]

--- a/bluez-generated/Cargo.toml
+++ b/bluez-generated/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bluez-generated"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Andrew Walbran <qwandor@google.com>", "David Laban <alsuren@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/mijia/Cargo.toml
+++ b/mijia/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["blue", "bluetooth"]
 categories = ["hardware-support"]
 
 [dependencies]
-bluez-generated = { version = "0.1.0", path = "../bluez-generated" }
+bluez-generated = { version = "0.2.0", path = "../bluez-generated" }
 dbus = { version = "0.9.0", features = ["futures"] }
 dbus-tokio = "0.6.0"
 eyre = "0.6.2"

--- a/mijia/Cargo.toml
+++ b/mijia/Cargo.toml
@@ -4,7 +4,10 @@ version = "0.1.0"
 authors = ["Luis Félix <lcs.felix@gmail.com>", "Andrew Walbran <qwandor@google.com>", "David Laban <alsuren@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
+description = "A library for connecting to Xiaomi Mijia 2 bluetooth temperature/humidity sensors."
 repository = "https://github.com/alsuren/mijia-homie/"
+keywords = ["blue", "bluetooth"]
+categories = ["hardware-support"]
 
 [dependencies]
 bluez-generated = { version = "0.1.0", path = "../bluez-generated" }


### PR DESCRIPTION
We need to publish a new version of `bluez-generated` before the `mijia` crate can be published, because we updated to a new version of `dbus` since it was last published.