### PR TITLE
homie-device: Increment version for release.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "homie-device"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-channel",
  "futures",

--- a/homie-device/Cargo.toml
+++ b/homie-device/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "homie-device"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Andrew Walbran <qwandor@google.com>", "David Laban <alsuren@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/mijia-homie/Cargo.toml
+++ b/mijia-homie/Cargo.toml
@@ -16,7 +16,7 @@ eyre = "0.6.2"
 dotenv = "0.15.0"
 futures = "0.3.7"
 futures-channel = "0.3.7"
-homie-device = { version = "0.2.0", path = "../homie-device" }
+homie-device = { version = "0.3.0", path = "../homie-device" }
 itertools = "0.9.0"
 log = "0.4.11"
 mijia = { version = "0.1.0", path = "../mijia" }


### PR DESCRIPTION
The version of `rumqttc` has been updated, which is an incompatible API change.