### PR TITLE
Use new homie-rs organisation and repository on Bintray.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ jobs:
       matrix:
         asset: ${{ github.event.release.assets }}
     steps:
-      - run: echo "${{ toJSON(matrix.asset) }}"
       - name: Download package from release
         run: wget ${{ matrix.asset.browser_download_url }}
       - name: Parse filename

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,8 @@ jobs:
           file: ${{ matrix.asset.name }}
           api_user: alsuren
           api_key: ${{ secrets.BINTRAY_API_KEY }}
-          repository_user: alsuren
-          repository: mijia-homie
+          repository_user: homie-rs
+          repository: homie-rs
           package: ${{ steps.parse_filename.outputs.group1 }}
           version: ${{ steps.parse_filename.outputs.group2 }}
           upload_path: pool/stable/main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions-ecosystem/action-regex-match@v2
         with:
           text: ${{ matrix.asset.name }}
-          regex: '^([a-z0-9-]+)_([0-9.-]+)_([a-z0-9]+).deb$'
+          regex: "^([a-z0-9-]+)_([0-9.-]+)_([a-z0-9]+).deb$"
       - name: Upload deb package to Bintray
         if: ${{ steps.parse_filename.outputs.match != '' }}
         uses: bpicode/github-action-upload-bintray@master

--- a/mijia-homie/README.md
+++ b/mijia-homie/README.md
@@ -6,6 +6,22 @@
 
 See [the main project readme](https://github.com/alsuren/mijia-homie#readme) for more details and background.
 
+## Installation
+
+It is recommended to install the latest release from our Debian repository:
+
+```sh
+$ curl -L https://bintray.com/user/downloadSubjectPublicKey?username=homie-rs | sudo apt-key add -
+$ echo "deb https://dl.bintray.com/homie-rs/homie-rs stable main" | sudo tee /etc/apt/sources.list.d/homie-rs.list
+$ sudo apt update && sudo apt install mijia-homie
+```
+
+Alternatively, you may install with cargo install, but that will require some more setup:
+
+```sh
+$ cargo install mijia-homie
+```
+
 ## Usage
 
 If you have installed the Debian package, the service will be set up with systemd for you already. Otherwise, copy the `mijia-homie` binary to `/usr/bin`, copy `debian/mijia-homie.service` to `/lib/systemd/system`, create a `mijia-homie` user to run as, and create `/etc/mijia-homie` for configuration files.


### PR DESCRIPTION
This has GPG keys set up, and a description and everything.

Almost finishes #18.

This depends on https://github.com/alsuren/mijia-homie/pull/69.