### PR TITLE
Build Debian packages for homie-influx too

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -3,7 +3,7 @@ name: Package
 on:
   push:
     branches: [master]
-    tags: ["mijia-homie-*"]
+    tags: ["homie-influx-*", "mijia-homie-*"]
 
 env:
   CARGO_TERM_COLOR: always
@@ -62,7 +62,10 @@ jobs:
           use-cross: true
           command: build
           args: --release --target ${{ matrix.target }}
-      - name: Package
+      - name: Package homie-influx
+        working-directory: homie-influx
+        run: cargo deb --target ${{ matrix.target }} --no-build
+      - name: Package mijia-homie
         working-directory: mijia-homie
         run: cargo deb --target ${{ matrix.target }} --no-build
 
@@ -76,19 +79,18 @@ jobs:
     name: Draft release
     runs-on: ubuntu-latest
     needs: build
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/mijia-homie-')
+    if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/homie-influx-') || startsWith(github.ref, 'refs/tags/mijia-homie-'))
     steps:
       - name: Download packages
         uses: actions/download-artifact@v2
         with:
           name: debian-packages
-      - name: Get version
-        id: version
-        uses: frabert/replace-string-action@v1.2
+      - name: Parse tag for package and version
+        id: parse_tag
+        uses: actions-ecosystem/action-regex-match@v2
         with:
-          string: ${{ github.ref }}
-          pattern: "refs/tags/mijia-homie-(.+)"
-          replace-with: "$1"
+          text: ${{ github.ref }}
+          regex: "^refs/tags/(homie-influx|mijia-homie)-(.+)$"
       - name: Create draft release
         id: create_release
         uses: actions/create-release@v1
@@ -96,12 +98,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions.
         with:
           tag_name: ${{ github.ref }}
-          release_name: mijia-homie release ${{ steps.version.outputs.replaced }}
+          release_name: ${{ steps.parse_tag.outputs.group1 }} release ${{ steps.parse_tag.outputs.group2 }}
           draft: true
           prerelease: false
       - name: Upload packages to release
         uses: shogo82148/actions-upload-release-asset@v1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: "*.deb"
+          asset_path: "${{ steps.parse_tag.outputs.group1 }}_*.deb"
           asset_content_type: application/vnd.debian.binary-package

--- a/homie-influx/Cargo.toml
+++ b/homie-influx/Cargo.toml
@@ -23,3 +23,18 @@ rustls = "0.18.1"
 rustls-native-certs = "0.4.0"
 stable-eyre = "0.2.1"
 tokio = "0.2.22"
+
+[package.metadata.deb]
+depends = "$auto, adduser"
+section = "net"
+maintainer-scripts = "debian-scripts"
+conf-files = ["/etc/homie-influx/.env", "/ect/homie-influx/mappings.conf"]
+assets = [
+	["target/release/homie-influx", "usr/bin/", "755"],
+	[".env.example", "etc/homie-influx/.env", "644"],
+	["mappings.conf.example", "etc/homie-influx/mappings.conf", "644"],
+	["README.md", "usr/share/doc/homie-influx/", "644"],
+]
+
+# This section needs to be here even if it's empty, for the systemd integration to work.
+[package.metadata.deb.systemd-units]

--- a/homie-influx/README.md
+++ b/homie-influx/README.md
@@ -1,0 +1,59 @@
+# Homie device InfluxDB logger
+
+[![crates.io page](https://img.shields.io/crates/v/homie-influx.svg)](https://crates.io/crates/homie-influx)
+
+`homie-influx` is a service to connect to an MQTT broker, discover devices following the [Homie convention](https://homieiot.github.io/), and record their property value changes to an InfluxDB database.
+
+See [the main project readme](https://github.com/alsuren/mijia-homie#readme) for more details and background.
+
+## Installation
+
+It is recommended to install the latest release from our Debian repository:
+
+```sh
+$ curl -L https://bintray.com/user/downloadSubjectPublicKey?username=homie-rs | sudo apt-key add -
+$ echo "deb https://dl.bintray.com/homie-rs/homie-rs stable main" | sudo tee /etc/apt/sources.list.d/homie-rs.list
+$ sudo apt update && sudo apt install homie-influx
+```
+
+Alternatively, you may install with cargo install, but that will require some more setup:
+
+```sh
+$ cargo install homie-influx
+```
+
+## Usage
+
+If you have installed the Debian package, the service will be set up with systemd for you already. Otherwise, copy the `homie-influx` binary to `/usr/bin`, copy `debian-scripts/homie-influx.service` to `/lib/systemd/system`, create a `homie-influx` user to run as, and create `/etc/homie-influx` for configuration files.
+
+There should be two config files under `/etc/homie-influx`:
+
+- `.env` contains the main configuration for the service, such as which MQTT broker and InfluxDB server to connect to. See [.env.example](.env.example) for an example of the settings that are supported.
+- `mappings.conf` contains a map of Homie base topics to InfluxDB databases. By default it will look for devices under the standard `homie` base topic and write to an InfluxDB database called `test`. You can add multiple base topics to handle multiple users.
+
+After editing these config files you will need to restart the service:
+
+```sh
+$ sudo systemctl restart homie-influx.service
+```
+
+You may find it helpful to watch the logs to see whether it is managing to connect:
+
+```sh
+$ sudo journalctl -u homie-influx.service --output=cat --follow
+```
+
+## License
+
+Licensed under either of
+
+- [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+- [MIT license](http://opensource.org/licenses/MIT)
+
+at your option.
+
+## Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.

--- a/homie-influx/debian-scripts/homie-influx.service
+++ b/homie-influx/debian-scripts/homie-influx.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Service to log Homie MQTT device properties to InfluxDB.
+After=network.target
+
+[Service]
+Type=simple
+User=homie-influx
+WorkingDirectory=/etc/homie-influx
+Environment=RUST_BACKTRACE=1
+Environment=RUST_LIB_BACKTRACE=1
+ExecStart=/usr/bin/homie-influx
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/homie-influx/debian-scripts/postinst
+++ b/homie-influx/debian-scripts/postinst
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = "configure" ] ; then
+  adduser --system --home /etc/homie-influx homie-influx
+fi
+
+#DEBHELPER#

--- a/mijia-homie/README.md
+++ b/mijia-homie/README.md
@@ -24,7 +24,7 @@ $ cargo install mijia-homie
 
 ## Usage
 
-If you have installed the Debian package, the service will be set up with systemd for you already. Otherwise, copy the `mijia-homie` binary to `/usr/bin`, copy `debian/mijia-homie.service` to `/lib/systemd/system`, create a `mijia-homie` user to run as, and create `/etc/mijia-homie` for configuration files.
+If you have installed the Debian package, the service will be set up with systemd for you already. Otherwise, copy the `mijia-homie` binary to `/usr/bin`, copy `debian-scripts/mijia-homie.service` to `/lib/systemd/system`, create a `mijia-homie` user to run as, and create `/etc/mijia-homie` for configuration files.
 
 There should be two config files under `/etc/mijia-homie`:
 


### PR DESCRIPTION
This adds the service file, Debian package config, and updates the Github workflow to package it too.

Helps with #34 and #18.