### PR TITLE
restart always, even if something goes wrong at boot

### DIFF
--- a/mijia-homie.service
+++ b/mijia-homie.service
@@ -2,6 +2,9 @@
 Description=mijia-homie - send temperature readings to mqtt
 After=network.target
 
+# https://selivan.github.io/2017/12/30/systemd-serice-always-restart.html
+StartLimitIntervalSec=0
+
 [Service]
 Type=simple
 User=pi
@@ -10,6 +13,7 @@ Environment=RUST_BACKTRACE=1
 Environment=RUST_LIB_BACKTRACE=1
 ExecStart=/home/pi/mijia-homie
 Restart=always
+RestartSec=1
 
 [Install]
 WantedBy=multi-user.target

--- a/mijia-homie.service
+++ b/mijia-homie.service
@@ -13,7 +13,7 @@ Environment=RUST_BACKTRACE=1
 Environment=RUST_LIB_BACKTRACE=1
 ExecStart=/home/pi/mijia-homie
 Restart=always
-RestartSec=1
+RestartSec=10
 
 [Install]
 WantedBy=multi-user.target

--- a/mijia-homie/debian-scripts/mijia-homie.service
+++ b/mijia-homie/debian-scripts/mijia-homie.service
@@ -2,6 +2,9 @@
 Description=Bluetooth temperature sensor to MQTT publisher
 After=network.target
 
+# https://selivan.github.io/2017/12/30/systemd-serice-always-restart.html
+StartLimitIntervalSec=0
+
 [Service]
 Type=simple
 User=mijia-homie
@@ -10,6 +13,7 @@ Environment=RUST_BACKTRACE=1
 Environment=RUST_LIB_BACKTRACE=1
 ExecStart=/usr/bin/mijia-homie
 Restart=always
+RestartSec=10
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Just noticed that cottagepi wasn't coming up after a power-cycle. Maybe this will help (following advice from https://selivan.github.io/2017/12/30/systemd-serice-always-restart.html).

Just pushing it to the device with run.sh now.