### PR TITLE
Various fixes for homie-influx

### DIFF
--- a/homie-controller/src/lib.rs
+++ b/homie-controller/src/lib.rs
@@ -147,6 +147,11 @@ impl HomieController {
         self.devices.lock().unwrap().clone()
     }
 
+    /// Get the Homie base topic which the controller was configured to use.
+    pub fn base_topic(&self) -> &str {
+        &self.base_topic
+    }
+
     /// Poll the `EventLoop`, and maybe return a Homie event.
     pub async fn poll(&self, event_loop: &mut HomieEventLoop) -> Result<Option<Event>, PollError> {
         let notification = event_loop.event_loop.poll().await?;

--- a/homie-influx/.env.example
+++ b/homie-influx/.env.example
@@ -1,4 +1,4 @@
-MQTT_CLIENT_NAME=homie-influx
+MQTT_CLIENT_PREFIX=homie-influx
 MQTT_HOST=test.mosquitto.org
 MQTT_PORT=1883
 # MQTT_USERNAME=

--- a/homie-influx/src/config.rs
+++ b/homie-influx/src/config.rs
@@ -8,7 +8,7 @@ use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::sync::Arc;
 
-const DEFAULT_MQTT_CLIENT_NAME: &str = "homie-influx";
+const DEFAULT_MQTT_CLIENT_PREFIX: &str = "homie-influx";
 const DEFAULT_MQTT_HOST: &str = "test.mosquitto.org";
 const DEFAULT_MQTT_PORT: u16 = 1883;
 const DEFAULT_INFLUXDB_URL: &str = "http://localhost:8086";
@@ -78,9 +78,10 @@ pub fn get_influxdb_client(database: &str) -> Result<Client, eyre::Report> {
 
 /// Construct the `MqttOptions` for connecting to the MQTT broker based on configuration options or
 /// defaults.
-pub fn get_mqtt_options() -> MqttOptions {
-    let client_name =
-        std::env::var("MQTT_CLIENT_NAME").unwrap_or_else(|_| DEFAULT_MQTT_CLIENT_NAME.to_string());
+pub fn get_mqtt_options(client_name_suffix: &str) -> MqttOptions {
+    let client_name_prefix = std::env::var("MQTT_CLIENT_PREFIX")
+        .unwrap_or_else(|_| DEFAULT_MQTT_CLIENT_PREFIX.to_string());
+    let client_name = format!("{}-{}", client_name_prefix, client_name_suffix);
 
     let mqtt_host = std::env::var("MQTT_HOST").unwrap_or_else(|_| DEFAULT_MQTT_HOST.to_string());
 

--- a/homie-influx/src/main.rs
+++ b/homie-influx/src/main.rs
@@ -47,11 +47,12 @@ fn spawn_homie_poll_loop(
 ) -> JoinHandle<Result<(), eyre::Report>> {
     task::spawn(async move {
         loop {
-            if let Some(event) = controller
-                .poll(&mut event_loop)
-                .await
-                .wrap_err("Failed to poll HomieController.")?
-            {
+            if let Some(event) = controller.poll(&mut event_loop).await.wrap_err_with(|| {
+                format!(
+                    "Failed to poll HomieController for base topic '{}'.",
+                    controller.base_topic()
+                )
+            })? {
                 match event {
                     Event::PropertyValueChanged {
                         device_id,

--- a/homie-influx/src/main.rs
+++ b/homie-influx/src/main.rs
@@ -76,7 +76,7 @@ fn spawn_homie_poll_loop(
                                 node_id,
                                 property_id,
                             )
-                            .await;
+                            .await?;
                         }
                     }
                     _ => {

--- a/homie-influx/src/main.rs
+++ b/homie-influx/src/main.rs
@@ -21,13 +21,12 @@ async fn main() -> Result<(), eyre::Report> {
 
     let mappings = read_mappings()?;
 
-    let mqtt_options = get_mqtt_options();
-
     // Start a task per mapping to poll the Homie MQTT connection and send values to InfluxDB.
     let mut join_handles: Vec<_> = Vec::new();
     for mapping in &mappings {
-        let (controller, event_loop) =
-            HomieController::new(mqtt_options.clone(), &mapping.homie_prefix);
+        // Include Homie base topic in client name, because client name must be unique.
+        let mqtt_options = get_mqtt_options(&mapping.homie_prefix);
+        let (controller, event_loop) = HomieController::new(mqtt_options, &mapping.homie_prefix);
         let controller = Arc::new(controller);
 
         let influxdb_client = get_influxdb_client(&mapping.influxdb_database)?;

--- a/mijia/src/bluetooth.rs
+++ b/mijia/src/bluetooth.rs
@@ -113,7 +113,7 @@ impl BluetoothSession {
         let dbus_handle = tokio::spawn(async {
             let err = dbus_resource.await;
             // TODO: work out why this err isn't 'static and use eyre::Error::new instead
-            Err::<(), eyre::Error>(eyre::eyre!(err))
+            Err(eyre::eyre!(err))
         });
         Ok((
             dbus_handle.map(|res| Ok(res??)),


### PR DESCRIPTION
Some minor improvements to error handling, and a bugfix to use a unique client name per MQTT connection. (Whoops, I didn't test this with more than one mapping before.)

Ref #34.