### PR TITLE
homie-controller: Update version number for release.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "homie-controller"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-channel",
  "futures",

--- a/homie-controller/Cargo.toml
+++ b/homie-controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "homie-controller"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Andrew Walbran <qwandor@google.com>", "David Laban <alsuren@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/homie-influx/Cargo.toml
+++ b/homie-influx/Cargo.toml
@@ -14,7 +14,7 @@ color-backtrace = "0.4.2"
 dotenv = "0.15.0"
 eyre = "0.6.2"
 futures = "0.3.7"
-homie-controller = { version = "0.1.0", path = "../homie-controller" }
+homie-controller = { version = "0.2.0", path = "../homie-controller" }
 influx_db_client = "0.4.5"
 log = "0.4.11"
 pretty_env_logger = "0.4.0"


### PR DESCRIPTION
The version of rumqttc was updated, which breaks compatibility of the public API.