### PR TITLE
Use `thiserror` rather than `eyre` in `mijia` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,6 +749,7 @@ dependencies = [
  "itertools",
  "log",
  "pretty_env_logger",
+ "thiserror",
  "tokio",
 ]
 
@@ -1479,18 +1480,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "318234ffa22e0920fe9a40d7b8369b5f649d490980cf7aadcf1eb91594869b42"
+checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae2447b6282786c3493999f40a9be2a6ad20cb8bd268b0a0dbf5a065535c0ab"
+checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,9 +261,9 @@ checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 
 [[package]]
 name = "eyre"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534ce924bff9118be8b28b24ede6bf7e96a00b53e4ded25050aa7b526e051e1a"
+checksum = "5f29abf4740a4778632fe27a4f681ef5b7a6f659aeba3330ac66f48e20cfa3b7"
 dependencies = [
  "indenter",
  "once_cell",

--- a/mijia-homie/src/main.rs
+++ b/mijia-homie/src/main.rs
@@ -422,7 +422,7 @@ async fn connect_and_subscribe_sensor_or_disconnect<'a>(
             .disconnect(id)
             .await
             .wrap_err_with(|| format!("disconnecting from {:?}", id))?;
-        Err(e)
+        Err(e.into())
     })
     .await
 }

--- a/mijia-homie/src/main.rs
+++ b/mijia-homie/src/main.rs
@@ -2,7 +2,7 @@
 
 use backoff::{future::FutureOperation, ExponentialBackoff};
 use futures::stream::StreamExt;
-use futures::{FutureExt, TryFutureExt};
+use futures::TryFutureExt;
 use homie_device::{Datatype, HomieDevice, Node, Property};
 use itertools::Itertools;
 use mijia::{DeviceId, MacAddress, MijiaEvent, MijiaSession, Readings, SensorProps};
@@ -64,9 +64,9 @@ async fn main() -> Result<(), eyre::Report> {
         // If this ever finishes, we lost connection to D-Bus.
         dbus_handle.err_into(),
         // Bluetooth finished first. Convert error and get on with your life.
-        sensor_handle.map(|res| Ok(res?)),
+        sensor_handle.err_into(),
         // MQTT event loop finished first.
-        homie_handle.map_err(|err| eyre::eyre!(err)),
+        homie_handle.err_into(),
     };
     res?;
     Ok(())

--- a/mijia/Cargo.toml
+++ b/mijia/Cargo.toml
@@ -17,6 +17,7 @@ eyre = "0.6.2"
 futures = "0.3.7"
 itertools = "0.9.0"
 log = "0.4.11"
+thiserror = "1.0.22"
 tokio = "0.2.22"
 
 [dev-dependencies]

--- a/mijia/Cargo.toml
+++ b/mijia/Cargo.toml
@@ -13,7 +13,6 @@ categories = ["hardware-support"]
 bluez-generated = { version = "0.2.0", path = "../bluez-generated" }
 dbus = { version = "0.9.0", features = ["futures"] }
 dbus-tokio = "0.6.0"
-eyre = "0.6.2"
 futures = "0.3.7"
 itertools = "0.9.0"
 log = "0.4.11"
@@ -22,4 +21,5 @@ tokio = "0.2.22"
 
 [dev-dependencies]
 chrono = "0.4.19"
+eyre = "0.6.3"
 pretty_env_logger = "0.4.0"

--- a/mijia/examples/list-sensors.rs
+++ b/mijia/examples/list-sensors.rs
@@ -5,7 +5,7 @@ use tokio::time;
 const SCAN_DURATION: Duration = Duration::from_secs(5);
 
 #[tokio::main]
-async fn main() -> Result<(), eyre::Error> {
+async fn main() -> Result<(), eyre::Report> {
     pretty_env_logger::init();
 
     let (_, session) = MijiaSession::new().await?;

--- a/mijia/examples/properties.rs
+++ b/mijia/examples/properties.rs
@@ -7,7 +7,7 @@ use tokio::time;
 const SCAN_DURATION: Duration = Duration::from_secs(5);
 
 #[tokio::main]
-async fn main() -> Result<(), eyre::Error> {
+async fn main() -> Result<(), eyre::Report> {
     pretty_env_logger::init();
 
     // If at least one command-line argument is given, we will only try to connect to sensors whose

--- a/mijia/src/bluetooth.rs
+++ b/mijia/src/bluetooth.rs
@@ -24,8 +24,6 @@ pub enum BluetoothError {
     /// There was an error talking to the BlueZ daemon over D-Bus.
     #[error(transparent)]
     DbusError(#[from] dbus::Error),
-    #[error("Invalid bus name: {0}")]
-    DbusInvalidBusName(String),
 }
 
 /// Error type for futures representing tasks spawned by this crate.

--- a/mijia/src/bluetooth.rs
+++ b/mijia/src/bluetooth.rs
@@ -30,7 +30,7 @@ pub enum BluetoothError {
 #[derive(Error, Debug)]
 pub enum SpawnError {
     #[error("D-Bus connection lost: {0}")]
-    DbusConnectionLost(String),
+    DbusConnectionLost(#[source] Box<dyn Error + Send + Sync>),
     #[error("Task failed: {0}")]
     Join(#[from] JoinError),
 }
@@ -133,7 +133,7 @@ impl BluetoothSession {
         // reactor ASAP. If the resource ever finishes, you lost connection to D-Bus.
         let dbus_handle = tokio::spawn(async {
             let err = dbus_resource.await;
-            Err(SpawnError::DbusConnectionLost(err.to_string()))
+            Err(SpawnError::DbusConnectionLost(err))
         });
         Ok((
             dbus_handle.map(|res| Ok(res??)),

--- a/mijia/src/bluetooth.rs
+++ b/mijia/src/bluetooth.rs
@@ -5,7 +5,6 @@ use core::future::Future;
 use dbus::arg::{RefArg, Variant};
 use dbus::nonblock::stdintf::org_freedesktop_dbus::ObjectManager;
 use dbus::nonblock::SyncConnection;
-use eyre::{bail, WrapErr};
 use futures::FutureExt;
 use itertools::Itertools;
 use std::collections::HashMap;
@@ -13,6 +12,28 @@ use std::error::Error;
 use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
 use std::sync::Arc;
+use thiserror::Error;
+use tokio::task::JoinError;
+
+/// An error carrying out a Bluetooth operation.
+#[derive(Debug, Error)]
+pub enum BluetoothError {
+    /// No Bluetooth adapters were found on the system.
+    #[error("No Bluetooth adapters found.")]
+    NoBluetoothAdapters,
+    /// There was an error talking to the BlueZ daemon over D-Bus.
+    #[error(transparent)]
+    DbusError(#[from] dbus::Error),
+}
+
+/// Error type for futures representing tasks spawned by this crate.
+#[derive(Error, Debug)]
+pub enum SpawnError {
+    #[error("D-Bus connection lost: {0}")]
+    DbusConnectionLost(String),
+    #[error("Task failed: {0}")]
+    Join(#[from] JoinError),
+}
 
 /// Opaque identifier for a Bluetooth device which the system knows about. This includes a reference
 /// to which Bluetooth adapter it was discovered on, which means that any attempt to connect to it
@@ -104,16 +125,15 @@ impl BluetoothSession {
     /// Returns a tuple of (join handle, Self).
     /// If the join handle ever completes then you're in trouble and should
     /// probably restart the process.
-    pub async fn new() -> Result<(impl Future<Output = Result<(), eyre::Error>>, Self), eyre::Error>
-    {
+    pub async fn new(
+    ) -> Result<(impl Future<Output = Result<(), SpawnError>>, Self), BluetoothError> {
         // Connect to the D-Bus system bus (this is blocking, unfortunately).
         let (dbus_resource, connection) = dbus_tokio::connection::new_system_sync()?;
         // The resource is a task that should be spawned onto a tokio compatible
         // reactor ASAP. If the resource ever finishes, you lost connection to D-Bus.
         let dbus_handle = tokio::spawn(async {
             let err = dbus_resource.await;
-            // TODO: work out why this err isn't 'static and use eyre::Error::new instead
-            Err(eyre::eyre!(err))
+            Err(SpawnError::DbusConnectionLost(err.to_string()))
         });
         Ok((
             dbus_handle.map(|res| Ok(res??)),
@@ -122,7 +142,7 @@ impl BluetoothSession {
     }
 
     /// Power on all Bluetooth adapters and start scanning for devices.
-    pub async fn start_discovery(&self) -> Result<(), eyre::Error> {
+    pub async fn start_discovery(&self) -> Result<(), BluetoothError> {
         let bluez_root = dbus::nonblock::Proxy::new(
             "org.bluez",
             "/",
@@ -136,7 +156,7 @@ impl BluetoothSession {
             .collect();
 
         if adapters.is_empty() {
-            bail!("No Bluetooth adapters found.");
+            return Err(BluetoothError::NoBluetoothAdapters);
         }
 
         for path in adapters {
@@ -157,7 +177,7 @@ impl BluetoothSession {
     }
 
     /// Get a list of all Bluetooth devices which have been discovered so far.
-    pub async fn get_devices(&self) -> Result<Vec<DeviceInfo>, eyre::Error> {
+    pub async fn get_devices(&self) -> Result<Vec<DeviceInfo>, BluetoothError> {
         let bluez_root = dbus::nonblock::Proxy::new(
             "org.bluez",
             "/",
@@ -212,19 +232,13 @@ impl BluetoothSession {
     }
 
     /// Connect to the Bluetooth device with the given D-Bus object path.
-    pub async fn connect(&self, id: &DeviceId) -> Result<(), eyre::Error> {
-        self.device(id)
-            .connect()
-            .await
-            .wrap_err_with(|| format!("connecting to {:?}", id))
+    pub async fn connect(&self, id: &DeviceId) -> Result<(), BluetoothError> {
+        Ok(self.device(id).connect().await?)
     }
 
     /// Disconnect from the Bluetooth device with the given D-Bus object path.
-    pub async fn disconnect(&self, id: &DeviceId) -> Result<(), eyre::Error> {
-        self.device(id)
-            .disconnect()
-            .await
-            .wrap_err_with(|| format!("disconnecting from {:?}", id))
+    pub async fn disconnect(&self, id: &DeviceId) -> Result<(), BluetoothError> {
+        Ok(self.device(id).disconnect().await?)
     }
 
     // TODO: Change this to lookup the path from the UUIDs instead.
@@ -234,7 +248,7 @@ impl BluetoothSession {
         &self,
         id: &DeviceId,
         characteristic_path: &str,
-    ) -> Result<Vec<u8>, eyre::Error> {
+    ) -> Result<Vec<u8>, BluetoothError> {
         let full_path = id.object_path.to_string() + characteristic_path;
         let characteristic = dbus::nonblock::Proxy::new(
             "org.bluez",
@@ -253,7 +267,7 @@ impl BluetoothSession {
         id: &DeviceId,
         characteristic_path: &str,
         value: impl Into<Vec<u8>>,
-    ) -> Result<(), eyre::Error> {
+    ) -> Result<(), BluetoothError> {
         let full_path = id.object_path.to_string() + characteristic_path;
         let characteristic = dbus::nonblock::Proxy::new(
             "org.bluez",

--- a/mijia/src/bluetooth.rs
+++ b/mijia/src/bluetooth.rs
@@ -24,6 +24,8 @@ pub enum BluetoothError {
     /// There was an error talking to the BlueZ daemon over D-Bus.
     #[error(transparent)]
     DbusError(#[from] dbus::Error),
+    #[error("Invalid bus name: {0}")]
+    DbusInvalidBusName(String),
 }
 
 /// Error type for futures representing tasks spawned by this crate.

--- a/mijia/src/decode/mod.rs
+++ b/mijia/src/decode/mod.rs
@@ -3,19 +3,56 @@ pub mod readings;
 pub mod temperature_unit;
 pub mod time;
 
-use eyre::bail;
+use std::time::SystemTime;
+use thiserror::Error;
 
 const TEMPERATURE_MAX: f32 = i16::MAX as f32 * 0.01;
 const TEMPERATURE_MIN: f32 = i16::MIN as f32 * 0.01;
+
+/// An error decoding a property from a sensor.
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+pub enum DecodeError {
+    /// The value being decoded wasn't the expected length.
+    #[error("Wrong length {length}, expected {expected_length}")]
+    WrongLength {
+        length: usize,
+        expected_length: usize,
+    },
+    /// The value being decoded was invalid in some other way.
+    #[error("{0}")]
+    InvalidValue(String),
+}
+
+/// An error encoding a property to be sent to a sensor.
+#[derive(Clone, Debug, Error)]
+pub enum EncodeError {
+    /// The temperature value given is out of the range which can be encoded.
+    #[error("Temperature {0} out of range.")]
+    TemperatureOutOfRange(f32),
+    /// The time value given is out of the range which can be encoded.
+    #[error("Time {0:?} out of range.")]
+    TimeOutOfRange(SystemTime),
+}
 
 fn decode_temperature(bytes: [u8; 2]) -> f32 {
     i16::from_le_bytes(bytes) as f32 * 0.01
 }
 
-fn encode_temperature(temperature: f32) -> Result<[u8; 2], eyre::Report> {
+fn encode_temperature(temperature: f32) -> Result<[u8; 2], EncodeError> {
     if temperature < TEMPERATURE_MIN || temperature > TEMPERATURE_MAX {
-        bail!("Temperature {} out of range.", temperature);
+        return Err(EncodeError::TemperatureOutOfRange(temperature));
     }
     let temperature_fixed = (temperature * 100.0) as i16;
     Ok(temperature_fixed.to_le_bytes())
+}
+
+fn check_length(length: usize, expected_length: usize) -> Result<(), DecodeError> {
+    if length != expected_length {
+        Err(DecodeError::WrongLength {
+            length,
+            expected_length,
+        })
+    } else {
+        Ok(())
+    }
 }

--- a/mijia/src/decode/temperature_unit.rs
+++ b/mijia/src/decode/temperature_unit.rs
@@ -1,4 +1,4 @@
-use eyre::bail;
+use crate::decode::{check_length, DecodeError};
 use std::fmt::{self, Display, Formatter};
 
 /// The temperature unit which a Mijia sensor uses for its display.
@@ -11,15 +11,16 @@ pub enum TemperatureUnit {
 }
 
 impl TemperatureUnit {
-    pub(crate) fn decode(value: &[u8]) -> Result<TemperatureUnit, eyre::Report> {
-        if value.len() != 1 {
-            bail!("Wrong length {} for temperature unit", value.len());
-        }
+    pub(crate) fn decode(value: &[u8]) -> Result<TemperatureUnit, DecodeError> {
+        check_length(value.len(), 1)?;
 
         match value[0] {
             0x00 => Ok(TemperatureUnit::Celcius),
             0x01 => Ok(TemperatureUnit::Fahrenheit),
-            byte => bail!("Invalid temperature unit value 0x{:x}", byte),
+            byte => Err(DecodeError::InvalidValue(format!(
+                "Invalid temperature unit value 0x{:x}",
+                byte
+            ))),
         }
     }
 

--- a/mijia/src/lib.rs
+++ b/mijia/src/lib.rs
@@ -118,7 +118,7 @@ impl MijiaSession {
             .bt_session
             .read_characteristic_value(id, CLOCK_CHARACTERISTIC_PATH)
             .await?;
-        decode_time(&value)
+        Ok(decode_time(&value)?)
     }
 
     /// Set the current time of the sensor.
@@ -138,7 +138,7 @@ impl MijiaSession {
             .bt_session
             .read_characteristic_value(id, TEMPERATURE_UNIT_CHARACTERISTIC_PATH)
             .await?;
-        TemperatureUnit::decode(&value)
+        Ok(TemperatureUnit::decode(&value)?)
     }
 
     /// Set the temperature unit which the sensor uses for its display.
@@ -158,7 +158,7 @@ impl MijiaSession {
             .bt_session
             .read_characteristic_value(id, COMFORT_LEVEL_CHARACTERISTIC_PATH)
             .await?;
-        ComfortLevel::decode(&value)
+        Ok(ComfortLevel::decode(&value)?)
     }
 
     /// Set the comfort level configuration which determines when the sensor displays a happy face.

--- a/mijia/src/lib.rs
+++ b/mijia/src/lib.rs
@@ -53,7 +53,7 @@ impl MijiaEvent {
             Some(BluetoothEvent::Value { object_path, value }) => {
                 // TODO: Make this less hacky.
                 let object_path = object_path.strip_suffix(SENSOR_READING_CHARACTERISTIC_PATH)?;
-                let readings = Readings::decode(&value)?;
+                let readings = Readings::decode(&value).ok()?;
                 Some(MijiaEvent::Readings {
                     id: DeviceId::new(object_path),
                     readings,

--- a/mijia/src/lib.rs
+++ b/mijia/src/lib.rs
@@ -160,7 +160,7 @@ impl MijiaSession {
         &self,
         id: &DeviceId,
         unit: TemperatureUnit,
-    ) -> Result<(), MijiaError> {
+    ) -> Result<(), BluetoothError> {
         Ok(self
             .bt_session
             .write_characteristic_value(id, TEMPERATURE_UNIT_CHARACTERISTIC_PATH, unit.encode())

--- a/mijia/src/lib.rs
+++ b/mijia/src/lib.rs
@@ -229,10 +229,9 @@ impl MijiaSession {
     ) -> Result<(MsgMatch, impl Stream<Item = MijiaEvent>), BluetoothError> {
         let mut rule = dbus::message::MatchRule::new();
         rule.msg_type = Some(dbus::message::MessageType::Signal);
-        rule.sender = Some(
-            dbus::strings::BusName::new("org.bluez")
-                .map_err(|e| BluetoothError::DbusInvalidBusName(e))?,
-        );
+        // BusName validation just checks that the length and format is valid, so it should never
+        // fail for a constant that we know is valid.
+        rule.sender = Some(dbus::strings::BusName::new("org.bluez").unwrap());
 
         let (msg_match, events) = self
             .bt_session


### PR DESCRIPTION
It seems more appropriate for a library.