### PR TITLE
Handle Homie property datatypes better in homie-device

### DIFF
--- a/homie-device/examples/light.rs
+++ b/homie-device/examples/light.rs
@@ -1,4 +1,4 @@
-use homie_device::{Datatype, HomieDevice, Node, Property, SpawnError};
+use homie_device::{ColorFormat, HomieDevice, Node, Property, SpawnError};
 use rumqttc::MqttOptions;
 
 #[tokio::main]
@@ -20,8 +20,8 @@ async fn main() -> Result<(), SpawnError> {
         "Light",
         "light",
         vec![
-            Property::new("power", "On", Datatype::Boolean, true, None, None),
-            Property::new("colour", "Colour", Datatype::Color, true, None, Some("rgb")),
+            Property::boolean("power", "On", true, None),
+            Property::color("colour", "Colour", true, None, ColorFormat::RGB),
         ],
     );
     homie.add_node(node).await?;

--- a/homie-device/examples/light.rs
+++ b/homie-device/examples/light.rs
@@ -1,4 +1,4 @@
-use homie_device::{ColorFormat, HomieDevice, Node, Property, SpawnError};
+use homie_device::{ColorFormat, ColorRGB, HomieDevice, Node, Property, SpawnError};
 use rumqttc::MqttOptions;
 
 #[tokio::main]
@@ -9,10 +9,7 @@ async fn main() -> Result<(), SpawnError> {
 
     let mut builder =
         HomieDevice::builder("homie/example_light", "Homie light example", mqttoptions);
-    builder.set_update_callback(|node_id, property_id, value| async move {
-        println!("{}/{} is now {}", node_id, property_id, value);
-        Some(value)
-    });
+    builder.set_update_callback(update_callback);
     let (mut homie, homie_handle) = builder.spawn().await?;
 
     let node = Node::new(
@@ -31,4 +28,30 @@ async fn main() -> Result<(), SpawnError> {
 
     // This will only resolve (with an error) if we lose connection to the MQTT broker.
     homie_handle.await
+}
+
+async fn update_callback(node_id: String, property_id: String, value: String) -> Option<String> {
+    match (node_id.as_ref(), property_id.as_ref()) {
+        ("light", "power") => {
+            set_power(value.parse().unwrap());
+        }
+        ("light", "colour") => {
+            set_colour(value.parse().unwrap());
+        }
+        _ => {
+            println!(
+                "Unexpected property {}/{} is now {}",
+                node_id, property_id, value
+            );
+        }
+    }
+    Some(value)
+}
+
+fn set_power(power: bool) {
+    println!("Power {}", power)
+}
+
+fn set_colour(colour: ColorRGB) {
+    println!("Colour {}", colour);
 }

--- a/homie-device/examples/sensor.rs
+++ b/homie-device/examples/sensor.rs
@@ -1,5 +1,5 @@
 use futures::{FutureExt, TryFutureExt};
-use homie_device::{Datatype, HomieDevice, Node, Property};
+use homie_device::{HomieDevice, Node, Property};
 use rand::random;
 use rumqttc::MqttOptions;
 use std::error::Error;
@@ -24,22 +24,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             "Sensor",
             "Environment sensor",
             vec![
-                Property::new(
-                    "temperature",
-                    "Temperature",
-                    Datatype::Float,
-                    false,
-                    Some("ºC"),
-                    None,
-                ),
-                Property::new(
-                    "humidity",
-                    "Humidity",
-                    Datatype::Integer,
-                    false,
-                    Some("%"),
-                    None,
-                ),
+                Property::float("temperature", "Temperature", false, Some("ºC"), None),
+                Property::integer("humidity", "Humidity", false, Some("%"), None),
             ],
         ))
         .await?;

--- a/homie-device/src/lib.rs
+++ b/homie-device/src/lib.rs
@@ -21,7 +21,7 @@ use tokio::task::{self, JoinError, JoinHandle};
 use tokio::time::delay_for;
 
 mod types;
-pub use crate::types::{Datatype, Node, Property};
+pub use crate::types::{ColorFormat, Datatype, Node, Property};
 
 const HOMIE_VERSION: &str = "4.0";
 const HOMIE_IMPLEMENTATION: &str = "homie-rs";

--- a/homie-device/src/lib.rs
+++ b/homie-device/src/lib.rs
@@ -43,11 +43,19 @@ pub enum SpawnError {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum State {
+    /// The device is connected to the MQTT broker but is not yet ready to operate.
     Init,
+    /// The device is connected and operational.
     Ready,
+    /// The device has cleanly disconnected from the MQTT broker.
     Disconnected,
+    /// The device is currently sleeping.
     Sleeping,
+    /// The device was uncleanly disconnected from the MQTT broker. This could happen due to a
+    /// network issue, power failure or some other unexpected failure.
     Lost,
+    /// The device is connected to the MQTT broker but something is wrong and it may require human
+    /// intervention.
     Alert,
 }
 

--- a/homie-device/src/lib.rs
+++ b/homie-device/src/lib.rs
@@ -21,7 +21,9 @@ use tokio::task::{self, JoinError, JoinHandle};
 use tokio::time::delay_for;
 
 mod types;
-pub use crate::types::{ColorFormat, Datatype, Node, Property};
+pub use crate::types::{Datatype, Node, Property};
+mod values;
+pub use crate::values::{Color, ColorFormat, ColorHSV, ColorRGB};
 
 const HOMIE_VERSION: &str = "4.0";
 const HOMIE_IMPLEMENTATION: &str = "homie-rs";

--- a/homie-device/src/types.rs
+++ b/homie-device/src/types.rs
@@ -1,4 +1,5 @@
-use std::fmt::Debug;
+use std::fmt::{self, Debug, Display, Formatter};
+use std::ops::Range;
 
 /// The data type for a Homie property.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -33,6 +34,31 @@ impl Into<Vec<u8>> for Datatype {
     }
 }
 
+/// The format of a [colour](https://homieiot.github.io/specification/#color) property, either RGB
+/// or HSV.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ColorFormat {
+    /// The colour is in red-green-blue format.
+    RGB,
+    /// The colour is in hue-saturation-value format.
+    HSV,
+}
+
+impl ColorFormat {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::RGB => "rgb",
+            Self::HSV => "hsv",
+        }
+    }
+}
+
+impl Display for ColorFormat {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// A [property](https://homieiot.github.io/specification/#properties) of a Homie node.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Property {
@@ -64,6 +90,9 @@ pub struct Property {
 impl Property {
     /// Create a new property with the given attributes.
     ///
+    /// This constructor allows you to create a property with any datatype, but doesn't check that
+    /// the `format` is valid. If possible, use the datatype-specific constructors instead.
+    ///
     /// # Arguments
     /// * `id`: The subtopic ID for the property. This must be unique per node, and follow the Homie
     ///   [ID format](https://homieiot.github.io/specification/#topic-ids).
@@ -85,13 +114,171 @@ impl Property {
         unit: Option<&str>,
         format: Option<&str>,
     ) -> Property {
+        Property::make(
+            id,
+            name,
+            datatype,
+            settable,
+            unit,
+            format.map(|s| s.to_owned()),
+        )
+    }
+
+    /// Create a new integer property with the given attributes.
+    ///
+    /// # Arguments
+    /// * `id`: The subtopic ID for the property. This must be unique per node, and follow the Homie
+    ///   [ID format](https://homieiot.github.io/specification/#topic-ids).
+    /// * `name`: The human-readable name of the property.
+    /// * `settable`: Whether the property can be set by the Homie controller. This should be true
+    ///   for properties like the brightness or power state of a light, and false for things like
+    ///   the temperature reading of a sensor.
+    /// * `unit`: The unit for the property, if any. This may be one of the
+    ///   [recommended units](https://homieiot.github.io/specification/#property-attributes), or
+    ///   any other custom unit.
+    /// * `format`: The valid range for the property, if any.
+    pub fn integer(
+        id: &str,
+        name: &str,
+        settable: bool,
+        unit: Option<&str>,
+        format: Option<Range<i64>>,
+    ) -> Property {
+        let format = format.map(|f| format!("{}:{}", f.start, f.end));
+        Property::make(id, name, Datatype::Integer, settable, unit, format)
+    }
+
+    /// Create a new floating-point property with the given attributes.
+    ///
+    /// # Arguments
+    /// * `id`: The subtopic ID for the property. This must be unique per node, and follow the Homie
+    ///   [ID format](https://homieiot.github.io/specification/#topic-ids).
+    /// * `name`: The human-readable name of the property.
+    /// * `settable`: Whether the property can be set by the Homie controller. This should be true
+    ///   for properties like the brightness or power state of a light, and false for things like
+    ///   the temperature reading of a sensor.
+    /// * `unit`: The unit for the property, if any. This may be one of the
+    ///   [recommended units](https://homieiot.github.io/specification/#property-attributes), or
+    ///   any other custom unit.
+    /// * `format`: The valid range for the property, if any.
+    pub fn float(
+        id: &str,
+        name: &str,
+        settable: bool,
+        unit: Option<&str>,
+        format: Option<Range<f64>>,
+    ) -> Property {
+        let format = format.map(|f| format!("{}:{}", f.start, f.end));
+        Property::make(id, name, Datatype::Float, settable, unit, format)
+    }
+
+    /// Create a new boolean property with the given attributes.
+    ///
+    /// # Arguments
+    /// * `id`: The subtopic ID for the property. This must be unique per node, and follow the Homie
+    ///   [ID format](https://homieiot.github.io/specification/#topic-ids).
+    /// * `name`: The human-readable name of the property.
+    /// * `settable`: Whether the property can be set by the Homie controller. This should be true
+    ///   for properties like the brightness or power state of a light, and false for things like
+    ///   the temperature reading of a sensor.
+    /// * `unit`: The unit for the property, if any. This may be one of the
+    ///   [recommended units](https://homieiot.github.io/specification/#property-attributes), or
+    ///   any other custom unit.
+    pub fn boolean(id: &str, name: &str, settable: bool, unit: Option<&str>) -> Property {
+        Property::make(id, name, Datatype::Boolean, settable, unit, None::<String>)
+    }
+
+    /// Create a new string property with the given attributes.
+    ///
+    /// # Arguments
+    /// * `id`: The subtopic ID for the property. This must be unique per node, and follow the Homie
+    ///   [ID format](https://homieiot.github.io/specification/#topic-ids).
+    /// * `name`: The human-readable name of the property.
+    /// * `settable`: Whether the property can be set by the Homie controller. This should be true
+    ///   for properties like the brightness or power state of a light, and false for things like
+    ///   the temperature reading of a sensor.
+    /// * `unit`: The unit for the property, if any. This may be one of the
+    ///   [recommended units](https://homieiot.github.io/specification/#property-attributes), or
+    ///   any other custom unit.
+    pub fn string(id: &str, name: &str, settable: bool, unit: Option<&str>) -> Property {
+        Property::make(id, name, Datatype::String, settable, unit, None::<String>)
+    }
+
+    /// Create a new enum property with the given attributes.
+    ///
+    /// # Arguments
+    /// * `id`: The subtopic ID for the property. This must be unique per node, and follow the Homie
+    ///   [ID format](https://homieiot.github.io/specification/#topic-ids).
+    /// * `name`: The human-readable name of the property.
+    /// * `settable`: Whether the property can be set by the Homie controller. This should be true
+    ///   for properties like the brightness or power state of a light, and false for things like
+    ///   the temperature reading of a sensor.
+    /// * `unit`: The unit for the property, if any. This may be one of the
+    ///   [recommended units](https://homieiot.github.io/specification/#property-attributes), or
+    ///   any other custom unit.
+    /// * `format`: The possible values for the enum.
+    pub fn enumeration(
+        id: &str,
+        name: &str,
+        settable: bool,
+        unit: Option<&str>,
+        format: &[&str],
+    ) -> Property {
+        Property::make(
+            id,
+            name,
+            Datatype::Enum,
+            settable,
+            unit,
+            Some(format.join(",")),
+        )
+    }
+
+    /// Create a new color property with the given attributes.
+    ///
+    /// # Arguments
+    /// * `id`: The subtopic ID for the property. This must be unique per node, and follow the Homie
+    ///   [ID format](https://homieiot.github.io/specification/#topic-ids).
+    /// * `name`: The human-readable name of the property.
+    /// * `settable`: Whether the property can be set by the Homie controller. This should be true
+    ///   for properties like the brightness or power state of a light, and false for things like
+    ///   the temperature reading of a sensor.
+    /// * `unit`: The unit for the property, if any. This may be one of the
+    ///   [recommended units](https://homieiot.github.io/specification/#property-attributes), or
+    ///   any other custom unit.
+    /// * `format`: The color format used for the property.
+    pub fn color(
+        id: &str,
+        name: &str,
+        settable: bool,
+        unit: Option<&str>,
+        format: ColorFormat,
+    ) -> Property {
+        Property::make(
+            id,
+            name,
+            Datatype::Color,
+            settable,
+            unit,
+            Some(format.to_string()),
+        )
+    }
+
+    pub fn make(
+        id: &str,
+        name: &str,
+        datatype: Datatype,
+        settable: bool,
+        unit: Option<&str>,
+        format: Option<String>,
+    ) -> Property {
         Property {
             id: id.to_owned(),
             name: name.to_owned(),
             datatype,
             settable,
             unit: unit.map(|s| s.to_owned()),
-            format: format.map(|s| s.to_owned()),
+            format,
         }
     }
 }
@@ -129,5 +316,54 @@ impl Node {
             node_type: node_type.to_owned(),
             properties,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn color_property_format() {
+        assert_eq!(
+            Property::color("id", "name", false, None, ColorFormat::RGB).format,
+            Some("rgb".to_string())
+        );
+        assert_eq!(
+            Property::color("id", "name", false, None, ColorFormat::HSV).format,
+            Some("hsv".to_string())
+        );
+    }
+
+    #[test]
+    fn integer_property_format() {
+        assert_eq!(
+            Property::integer("id", "name", false, None, None).format,
+            None
+        );
+        assert_eq!(
+            Property::integer("id", "name", false, None, Some(-2..5)).format,
+            Some("-2:5".to_string())
+        );
+    }
+
+    #[test]
+    fn float_property_format() {
+        assert_eq!(
+            Property::float("id", "name", false, None, None).format,
+            None
+        );
+        assert_eq!(
+            Property::float("id", "name", false, None, Some(-2.3..5.0)).format,
+            Some("-2.3:5".to_string())
+        );
+    }
+
+    #[test]
+    fn enum_property_format() {
+        assert_eq!(
+            Property::enumeration("id", "name", false, None, &["ab", "cd"]).format,
+            Some("ab,cd".to_string())
+        );
     }
 }

--- a/homie-device/src/types.rs
+++ b/homie-device/src/types.rs
@@ -3,11 +3,19 @@ use std::fmt::Debug;
 /// The data type for a Homie property.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Datatype {
+    /// A [64-bit signed integer](https://homieiot.github.io/specification/#integer).
     Integer,
+    /// A [64-bit floating-point number](https://homieiot.github.io/specification/#float).
     Float,
+    /// A [boolean value](https://homieiot.github.io/specification/#boolean).
     Boolean,
+    /// A [UTF-8 encoded string](https://homieiot.github.io/specification/#string).
     String,
+    /// An [enum value](https://homieiot.github.io/specification/#enum) from a set of possible
+    /// values specified by the property format.
     Enum,
+    /// An RGB or HSV [color](https://homieiot.github.io/specification/#color), depending on the
+    /// property format.
     Color,
 }
 
@@ -26,13 +34,30 @@ impl Into<Vec<u8>> for Datatype {
 }
 
 /// A [property](https://homieiot.github.io/specification/#properties) of a Homie node.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Property {
+    /// The subtopic ID of the property. This must be unique per node, and should follow the Homie
+    /// [ID format](https://homieiot.github.io/specification/#topic-ids).
     pub id: String,
+
+    /// The human-readable name of the property.
     pub name: String,
+
+    /// The data type of the property.
     pub datatype: Datatype,
+
+    /// Whether the property can be set by the Homie controller. This should be true for properties
+    /// like the brightness or power state of a light, and false for things like the temperature
+    /// reading of a sensor.
     pub settable: bool,
+
+    /// The unit of the property, if any. This may be one of the
+    /// [recommended units](https://homieiot.github.io/specification/#property-attributes), or any
+    /// other custom unit.
     pub unit: Option<String>,
+
+    /// The format of the property, if any. This must be specified if the datatype is `Enum` or
+    /// `Color`, and may be specified if the datatype is `Integer` or `Float`.
     pub format: Option<String>,
 }
 
@@ -40,7 +65,7 @@ impl Property {
     /// Create a new property with the given attributes.
     ///
     /// # Arguments
-    /// * `id`: The topic ID for the property. This must be unique per node, and follow the Homie
+    /// * `id`: The subtopic ID for the property. This must be unique per node, and follow the Homie
     ///   [ID format](https://homieiot.github.io/specification/#topic-ids).
     /// * `name`: The human-readable name of the property.
     /// * `datatype`: The data type of the property.
@@ -72,11 +97,19 @@ impl Property {
 }
 
 /// A [node](https://homieiot.github.io/specification/#nodes) of a Homie device.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Node {
+    /// The subtopic ID of the node. This must be unique per device, and should follow the Homie
+    /// [ID format](https://homieiot.github.io/specification/#topic-ids).
     pub id: String,
+
+    /// The human-readable name of the node.
     pub name: String,
+
+    /// The type of the node. This is an arbitrary string.
     pub node_type: String,
+
+    /// The properties of the node. There should be at least one.
     pub properties: Vec<Property>,
 }
 
@@ -84,7 +117,7 @@ impl Node {
     /// Create a new node with the given attributes.
     ///
     /// # Arguments
-    /// * `id`: The topic ID for the node. This must be unique per device, and follow the Homie
+    /// * `id`: The subtopic ID for the node. This must be unique per device, and follow the Homie
     ///   [ID format](https://homieiot.github.io/specification/#topic-ids).
     /// * `name`: The human-readable name of the node.
     /// * `type`: The type of the node. This is an arbitrary string.

--- a/homie-device/src/types.rs
+++ b/homie-device/src/types.rs
@@ -1,6 +1,8 @@
 use std::fmt::{self, Debug, Display, Formatter};
 use std::ops::Range;
 
+use crate::values::ColorFormat;
+
 /// The data type for a Homie property.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Datatype {
@@ -20,8 +22,8 @@ pub enum Datatype {
     Color,
 }
 
-impl Into<Vec<u8>> for Datatype {
-    fn into(self) -> Vec<u8> {
+impl Datatype {
+    fn as_str(&self) -> &'static str {
         match self {
             Self::Integer => "integer",
             Self::Float => "float",
@@ -30,32 +32,18 @@ impl Into<Vec<u8>> for Datatype {
             Self::Enum => "enum",
             Self::Color => "color",
         }
-        .into()
     }
 }
 
-/// The format of a [colour](https://homieiot.github.io/specification/#color) property, either RGB
-/// or HSV.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum ColorFormat {
-    /// The colour is in red-green-blue format.
-    RGB,
-    /// The colour is in hue-saturation-value format.
-    HSV,
-}
-
-impl ColorFormat {
-    fn as_str(&self) -> &'static str {
-        match self {
-            Self::RGB => "rgb",
-            Self::HSV => "hsv",
-        }
-    }
-}
-
-impl Display for ColorFormat {
+impl Display for Datatype {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         f.write_str(self.as_str())
+    }
+}
+
+impl Into<Vec<u8>> for Datatype {
+    fn into(self) -> Vec<u8> {
+        self.as_str().into()
     }
 }
 

--- a/homie-device/src/values.rs
+++ b/homie-device/src/values.rs
@@ -1,0 +1,141 @@
+use std::fmt::{self, Debug, Display, Formatter};
+use std::num::ParseIntError;
+use std::str::FromStr;
+use thiserror::Error;
+
+/// The format of a [colour](https://homieiot.github.io/specification/#color) property, either RGB
+/// or HSV.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ColorFormat {
+    /// The colour is in red-green-blue format.
+    RGB,
+    /// The colour is in hue-saturation-value format.
+    HSV,
+}
+
+impl ColorFormat {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::RGB => "rgb",
+            Self::HSV => "hsv",
+        }
+    }
+}
+
+impl Display for ColorFormat {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+pub trait Color {
+    fn format() -> ColorFormat;
+}
+
+/// An error while attempting to parse a `Color` from a string.
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+#[error("Failed to parse color.")]
+pub struct ParseColorError();
+
+impl From<ParseIntError> for ParseColorError {
+    fn from(_: ParseIntError) -> Self {
+        ParseColorError()
+    }
+}
+
+/// A [colour](https://homieiot.github.io/specification/#color) in red-green-blue format.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ColorRGB {
+    /// The red channel of the colour, between 0 and 255.
+    pub r: u8,
+    /// The green channel of the colour, between 0 and 255.
+    pub g: u8,
+    /// The blue channel of the colour, between 0 and 255.
+    pub b: u8,
+}
+
+impl ColorRGB {
+    /// Construct a new RGB colour.
+    pub fn new(r: u8, g: u8, b: u8) -> Self {
+        ColorRGB { r, g, b }
+    }
+}
+
+impl Display for ColorRGB {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{},{},{}", self.r, self.g, self.b)
+    }
+}
+
+impl FromStr for ColorRGB {
+    type Err = ParseColorError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<_> = s.split(',').collect();
+        if let [r, g, b] = parts.as_slice() {
+            Ok(ColorRGB {
+                r: r.parse()?,
+                g: g.parse()?,
+                b: b.parse()?,
+            })
+        } else {
+            Err(ParseColorError())
+        }
+    }
+}
+
+impl Color for ColorRGB {
+    fn format() -> ColorFormat {
+        ColorFormat::RGB
+    }
+}
+
+/// A [colour](https://homieiot.github.io/specification/#color) in hue-saturation-value format.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ColorHSV {
+    /// The hue of the colour, between 0 and 360.
+    pub h: u16,
+    /// The saturation of the colour, between 0 and 100.
+    pub s: u8,
+    /// The value of the colour, between 0 and 100.
+    pub v: u8,
+}
+
+impl ColorHSV {
+    /// Construct a new HSV colour, or panic if the values given are out of range.
+    pub fn new(h: u16, s: u8, v: u8) -> Self {
+        assert!(h <= 360);
+        assert!(s <= 100);
+        assert!(v <= 100);
+        ColorHSV { h, s, v }
+    }
+}
+
+impl Display for ColorHSV {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{},{},{}", self.h, self.s, self.v)
+    }
+}
+
+impl FromStr for ColorHSV {
+    type Err = ParseColorError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<_> = s.split(',').collect();
+        if let [h, s, v] = parts.as_slice() {
+            let h = h.parse()?;
+            let s = s.parse()?;
+            let v = v.parse()?;
+            if h <= 360 && s <= 100 && v <= 100 {
+                return Ok(ColorHSV { h, s, v });
+            }
+        }
+        Err(ParseColorError())
+    }
+}
+
+impl Color for ColorHSV {
+    fn format() -> ColorFormat {
+        ColorFormat::HSV
+    }
+}

--- a/mijia-homie/src/main.rs
+++ b/mijia-homie/src/main.rs
@@ -3,7 +3,7 @@
 use backoff::{future::FutureOperation, ExponentialBackoff};
 use futures::stream::StreamExt;
 use futures::TryFutureExt;
-use homie_device::{Datatype, HomieDevice, Node, Property};
+use homie_device::{HomieDevice, Node, Property};
 use itertools::Itertools;
 use mijia::{DeviceId, MacAddress, MijiaEvent, MijiaSession, Readings, SensorProps};
 use rumqttc::MqttOptions;
@@ -160,26 +160,23 @@ impl Sensor {
             &self.name,
             "Mijia sensor",
             vec![
-                Property::new(
+                Property::float(
                     Self::PROPERTY_ID_TEMPERATURE,
                     "Temperature",
-                    Datatype::Float,
                     false,
                     Some("ºC"),
                     None,
                 ),
-                Property::new(
+                Property::integer(
                     Self::PROPERTY_ID_HUMIDITY,
                     "Humidity",
-                    Datatype::Integer,
                     false,
                     Some("%"),
                     None,
                 ),
-                Property::new(
+                Property::integer(
                     Self::PROPERTY_ID_BATTERY,
                     "Battery level",
-                    Datatype::Integer,
                     false,
                     Some("%"),
                     None,


### PR DESCRIPTION
This adds separate datatype-specific constructors to `Property` which take the appropriate type of format (if any) rather than an arbitrary string, and types for parsing colour values.

Fixes #35.