### PR TITLE
Config files containing secrets should not be world-readable.

### DIFF
--- a/homie-influx/Cargo.toml
+++ b/homie-influx/Cargo.toml
@@ -34,7 +34,7 @@ maintainer-scripts = "debian-scripts"
 conf-files = ["/etc/homie-influx/homie-influx.toml", "/etc/homie-influx/mappings.toml"]
 assets = [
 	["target/release/homie-influx", "usr/bin/", "755"],
-	["homie-influx.example.toml", "etc/homie-influx/homie-influx.toml", "644"],
+	["homie-influx.example.toml", "etc/homie-influx/homie-influx.toml", "640"],
 	["mappings.example.toml", "etc/homie-influx/mappings.toml", "644"],
 	["README.md", "usr/share/doc/homie-influx/", "644"],
 ]

--- a/homie-influx/debian-scripts/postinst
+++ b/homie-influx/debian-scripts/postinst
@@ -4,6 +4,7 @@ set -e
 
 if [ "$1" = "configure" ] ; then
   adduser --system --home /etc/homie-influx homie-influx
+  chown homie-influx /etc/homie-influx/homie-influx.toml
 fi
 
 #DEBHELPER#

--- a/homie-influx/debian-scripts/postinst
+++ b/homie-influx/debian-scripts/postinst
@@ -3,7 +3,7 @@
 set -e
 
 if [ "$1" = "configure" ] ; then
-  adduser --system --home /etc/homie-influx homie-influx
+  adduser --system --no-create-home --home /etc/homie-influx homie-influx
   chown homie-influx /etc/homie-influx/homie-influx.toml
 fi
 

--- a/mijia-homie/Cargo.toml
+++ b/mijia-homie/Cargo.toml
@@ -36,7 +36,7 @@ maintainer-scripts = "debian-scripts"
 conf-files = ["/etc/mijia-homie/mijia-homie.toml"]
 assets = [
 	["target/release/mijia-homie", "usr/bin/", "755"],
-	["mijia-homie.example.toml", "etc/mijia-homie/mijia-homie.toml", "644"],
+	["mijia-homie.example.toml", "etc/mijia-homie/mijia-homie.toml", "640"],
 	["README.md", "usr/share/doc/mijia-homie/", "644"],
 ]
 

--- a/mijia-homie/debian-scripts/postinst
+++ b/mijia-homie/debian-scripts/postinst
@@ -4,7 +4,7 @@ set -e
 
 if [ "$1" = "configure" ] ; then
   touch /etc/mijia-homie/sensor-names.toml
-  adduser --system --home /etc/mijia-homie mijia-homie
+  adduser --system --no-create-home --home /etc/mijia-homie mijia-homie
   adduser mijia-homie bluetooth
   chown mijia-homie /etc/mijia-homie/mijia-homie.toml
 fi

--- a/mijia-homie/debian-scripts/postinst
+++ b/mijia-homie/debian-scripts/postinst
@@ -6,6 +6,7 @@ if [ "$1" = "configure" ] ; then
   touch /etc/mijia-homie/sensor-names.toml
   adduser --system --home /etc/mijia-homie mijia-homie
   adduser mijia-homie bluetooth
+  chown mijia-homie /etc/mijia-homie/mijia-homie.toml
 fi
 
 #DEBHELPER#


### PR DESCRIPTION
Change owner and permissions so that the service can still read them, but other users cannot.

Fixes #95.