### PR TITLE
Reconnect to MQTT broker if connection is dropped

### DIFF
--- a/homie-influx/debian-scripts/homie-influx.service
+++ b/homie-influx/debian-scripts/homie-influx.service
@@ -10,6 +10,7 @@ Environment=RUST_BACKTRACE=1
 Environment=RUST_LIB_BACKTRACE=1
 ExecStart=/usr/bin/homie-influx
 Restart=always
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/homie-influx/homie-influx.example.toml
+++ b/homie-influx/homie-influx.example.toml
@@ -15,6 +15,8 @@ client_prefix="homie-influx"
 #password=""
 # Whether to use TLS for the connection to the MQTT broker.
 use_tls=false
+# How long to wait between reconnection attempts if the MQTT connection is dropped.
+reconnect_interval_seconds=5
 
 [influxdb]
 # The URL of the InfluxDB to which to connect.

--- a/homie-influx/src/main.rs
+++ b/homie-influx/src/main.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<(), eyre::Report> {
         join_handles.push(handle);
     }
 
-    simplify_unit_vec(try_join_all(join_handles).await)?;
+    try_join_all(join_handles).await?;
     Ok(())
 }
 
@@ -110,8 +110,4 @@ async fn handle_event(controller: &HomieController, influx_db_client: &Client, e
             log::info!("{} Event: {:?}", controller.base_topic(), event);
         }
     }
-}
-
-fn simplify_unit_vec<E>(m: Result<Vec<()>, E>) -> Result<(), E> {
-    m.map(|_| ())
 }


### PR DESCRIPTION
This should fix the `homie-influx` part of #7. It also makes errors writing to InfluxDB non-fatal. There is no point crashing just because one database isn't working, as the others may still work.