### PR TITLE
Specify Debian package dependencies manually.

### DIFF
--- a/homie-influx/Cargo.toml
+++ b/homie-influx/Cargo.toml
@@ -28,7 +28,8 @@ toml = "0.5.7"
 url = { version = "2.2.0", features = ["serde"] }
 
 [package.metadata.deb]
-depends = "$auto, adduser"
+# $auto doesn't work because we don't build packages in the same container as we build the binaries.
+depends = "adduser, libssl1.0.0, libc6"
 section = "net"
 maintainer-scripts = "debian-scripts"
 conf-files = ["/etc/homie-influx/homie-influx.toml", "/etc/homie-influx/mappings.toml"]

--- a/mijia-homie/Cargo.toml
+++ b/mijia-homie/Cargo.toml
@@ -30,7 +30,8 @@ tokio = "0.2.24"
 toml = "0.5.7"
 
 [package.metadata.deb]
-depends = "$auto, adduser, bluez"
+# $auto doesn't work because we don't build packages in the same container as we build the binaries.
+depends = "adduser, bluez, libc6, libsystemd0, libgcrypt20, libdbus-1-3, libgpg-error0, liblzma5, liblz4-1"
 section = "net"
 maintainer-scripts = "debian-scripts"
 conf-files = ["/etc/mijia-homie/mijia-homie.toml"]


### PR DESCRIPTION
`$auto` doesn't work properly because we don't build the package in the same container as the binary (and not necessarily on the right architecture) so ldd doesn't do the right thing.

This works around #56.