### PR TITLE
fix release build

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -42,7 +42,7 @@ jobs:
             ~/.cargo/git
             ~/.cargo/registry
             target
-          key: ${{ runner.os }}-${{ matrix.target }}-package-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ matrix.target }}-package-cargo-${{ hashFiles('**/Cargo.lock', '**/Cross.toml') }}
       - name: Cache cargo-deb and cross
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
Fixes the release build after #102 . Binaries produced on ubuntu 16.04 do seem to work okay on debian buster. If they don't work on the vim3l then I will try to get the more complicated system merged upstream.