### PR TITLE
Add helper function to call introspect and parse XML.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-tungstenite"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1237,6 +1248,7 @@ dependencies = [
 name = "mijia"
 version = "0.2.0"
 dependencies = [
+ "async-trait",
  "bluez-generated",
  "chrono",
  "dbus",

--- a/mijia/Cargo.toml
+++ b/mijia/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["ble", "bluetooth", "humidity", "temperature"]
 categories = ["hardware-support"]
 
 [dependencies]
+async-trait = "0.1.42"
 bluez-generated = { version = "0.2.0", path = "../bluez-generated" }
 dbus = { version = "0.9.0", features = ["futures"] }
 dbus-tokio = "0.6.0"

--- a/mijia/src/bluetooth/introspect.rs
+++ b/mijia/src/bluetooth/introspect.rs
@@ -1,7 +1,6 @@
+use async_trait::async_trait;
 use dbus::nonblock::stdintf::org_freedesktop_dbus::Introspectable;
-use futures::Future;
 use serde_derive::Deserialize;
-use std::pin::Pin;
 
 use super::BluetoothError;
 
@@ -110,23 +109,18 @@ pub enum Access {
 }
 
 /// Extension trait to introspect D-Bus objects and parse the resulting XML into a typed structure.
+#[async_trait]
 pub trait IntrospectParse {
-    fn introspect_parse(
-        &self,
-    ) -> Pin<Box<dyn Future<Output = Result<Node, BluetoothError>> + Send>>;
+    async fn introspect_parse(&self) -> Result<Node, BluetoothError>;
 }
 
-impl<T: Introspectable> IntrospectParse for T {
+#[async_trait]
+impl<T: Introspectable + Sync> IntrospectParse for T {
     /// Introspect this object, and parse the resulting XML into a typed structure.
-    fn introspect_parse(
-        &self,
-    ) -> Pin<Box<dyn Future<Output = Result<Node, BluetoothError>> + Send>> {
-        let introspect_future = self.introspect();
-        Box::pin(async move {
-            let introspection_xml: String = introspect_future.await?;
-            let device_node: Node = serde_xml_rs::from_str(&introspection_xml)?;
-            Ok(device_node)
-        })
+    async fn introspect_parse(&self) -> Result<Node, BluetoothError> {
+        let introspection_xml: String = self.introspect().await?;
+        let device_node: Node = serde_xml_rs::from_str(&introspection_xml)?;
+        Ok(device_node)
     }
 }
 

--- a/mijia/src/bluetooth/introspect.rs
+++ b/mijia/src/bluetooth/introspect.rs
@@ -1,4 +1,7 @@
+use dbus::nonblock::stdintf::org_freedesktop_dbus::Introspectable;
 use serde_derive::Deserialize;
+
+use super::BluetoothError;
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct Node {
@@ -102,6 +105,12 @@ pub enum Access {
     Read,
     #[serde(rename = "write")]
     Write,
+}
+
+pub async fn introspect(introspectable: &impl Introspectable) -> Result<Node, BluetoothError> {
+    let introspection_xml: String = introspectable.introspect().await?;
+    let device_node: Node = serde_xml_rs::from_str(&introspection_xml)?;
+    Ok(device_node)
 }
 
 #[cfg(test)]

--- a/mijia/src/bluetooth/mod.rs
+++ b/mijia/src/bluetooth/mod.rs
@@ -5,7 +5,7 @@ mod messagestream;
 
 pub use self::bleuuid::{uuid_from_u16, uuid_from_u32, BleUuid};
 pub use self::events::{AdapterEvent, BluetoothEvent, CharacteristicEvent, DeviceEvent};
-use self::introspect::introspect;
+use self::introspect::IntrospectParse;
 use self::messagestream::MessageStream;
 use bluez_generated::{
     OrgBluezAdapter1, OrgBluezDevice1, OrgBluezGattCharacteristic1, OrgBluezGattService1,
@@ -339,7 +339,7 @@ impl BluetoothSession {
         &self,
         device: &DeviceId,
     ) -> Result<Vec<ServiceInfo>, BluetoothError> {
-        let device_node = introspect(&self.device(device)).compat().await?;
+        let device_node = self.device(device).introspect_parse().compat().await?;
         let mut services = vec![];
         for subnode in device_node.nodes {
             let subnode_name = subnode.name.as_ref().unwrap();
@@ -365,7 +365,7 @@ impl BluetoothSession {
         &self,
         service: &ServiceId,
     ) -> Result<Vec<CharacteristicInfo>, BluetoothError> {
-        let service_node = introspect(&self.service(service)).compat().await?;
+        let service_node = self.service(service).introspect_parse().compat().await?;
         let mut characteristics = vec![];
         for subnode in service_node.nodes {
             let subnode_name = subnode.name.as_ref().unwrap();

--- a/mijia/src/bluetooth/mod.rs
+++ b/mijia/src/bluetooth/mod.rs
@@ -5,7 +5,7 @@ mod messagestream;
 
 pub use self::bleuuid::{uuid_from_u16, uuid_from_u32, BleUuid};
 pub use self::events::{AdapterEvent, BluetoothEvent, CharacteristicEvent, DeviceEvent};
-use self::introspect::Node;
+use self::introspect::introspect;
 use self::messagestream::MessageStream;
 use bluez_generated::{
     OrgBluezAdapter1, OrgBluezDevice1, OrgBluezGattCharacteristic1, OrgBluezGattService1,
@@ -339,8 +339,7 @@ impl BluetoothSession {
         &self,
         device: &DeviceId,
     ) -> Result<Vec<ServiceInfo>, BluetoothError> {
-        let introspection_xml = self.device(device).introspect().compat().await?;
-        let device_node: Node = serde_xml_rs::from_str(&introspection_xml)?;
+        let device_node = introspect(&self.device(device)).compat().await?;
         let mut services = vec![];
         for subnode in device_node.nodes {
             let subnode_name = subnode.name.as_ref().unwrap();
@@ -366,8 +365,7 @@ impl BluetoothSession {
         &self,
         service: &ServiceId,
     ) -> Result<Vec<CharacteristicInfo>, BluetoothError> {
-        let introspection_xml = self.service(service).introspect().compat().await?;
-        let service_node: Node = serde_xml_rs::from_str(&introspection_xml)?;
+        let service_node = introspect(&self.service(service)).compat().await?;
         let mut characteristics = vec![];
         for subnode in service_node.nodes {
             let subnode_name = subnode.name.as_ref().unwrap();


### PR DESCRIPTION
This is a minor cleanup to put the introspection in the `introspect` module.

I tried to make an extension trait for `Introspectable`, but I couldn't see a way to do that without support for async functions on traits.