### PR TITLE
Add event for a new Bluetooth device being discovered

### DIFF
--- a/mijia/src/bluetooth/events.rs
+++ b/mijia/src/bluetooth/events.rs
@@ -133,7 +133,6 @@ mod tests {
     use std::collections::HashMap;
 
     use dbus::arg::{RefArg, Variant};
-    use dbus::Path;
 
     use super::*;
 
@@ -146,7 +145,7 @@ mod tests {
             changed_properties,
             invalidated_properties: vec![],
         };
-        let message = properties_changed.to_emit_message(&Path::new("/org/bluez/hci0").unwrap());
+        let message = properties_changed.to_emit_message(&"/org/bluez/hci0".into());
         let id = AdapterId::new("/org/bluez/hci0");
         assert_eq!(
             BluetoothEvent::message_to_events(message),
@@ -167,8 +166,8 @@ mod tests {
             changed_properties,
             invalidated_properties: vec![],
         };
-        let message = properties_changed
-            .to_emit_message(&Path::new("/org/bluez/hci0/dev_11_22_33_44_55_66").unwrap());
+        let message =
+            properties_changed.to_emit_message(&"/org/bluez/hci0/dev_11_22_33_44_55_66".into());
         let id = DeviceId::new("/org/bluez/hci0/dev_11_22_33_44_55_66");
         assert_eq!(
             BluetoothEvent::message_to_events(message),
@@ -189,9 +188,8 @@ mod tests {
             changed_properties,
             invalidated_properties: vec![],
         };
-        let message = properties_changed.to_emit_message(
-            &Path::new("/org/bluez/hci0/dev_11_22_33_44_55_66/service0012/char0034").unwrap(),
-        );
+        let message = properties_changed
+            .to_emit_message(&"/org/bluez/hci0/dev_11_22_33_44_55_66/service0012/char0034".into());
         let id =
             CharacteristicId::new("/org/bluez/hci0/dev_11_22_33_44_55_66/service0012/char0034");
         assert_eq!(

--- a/mijia/src/bluetooth/events.rs
+++ b/mijia/src/bluetooth/events.rs
@@ -113,7 +113,7 @@ impl BluetoothEvent {
     fn interfaces_added_to_events(
         interfaces_added: ObjectManagerInterfacesAdded,
     ) -> Vec<BluetoothEvent> {
-        log::trace!("InterfacesAdded: {:#?}", interfaces_added);
+        log::trace!("InterfacesAdded: {:?}", interfaces_added);
         let mut events = vec![];
         let object_path = interfaces_added.object;
         if let Some(_device) = interfaces_added.interfaces.get("org.bluez.Device1") {

--- a/mijia/src/bluetooth/events.rs
+++ b/mijia/src/bluetooth/events.rs
@@ -3,7 +3,7 @@ use dbus::message::{MatchRule, SignalArgs};
 use dbus::nonblock::stdintf::org_freedesktop_dbus::{
     ObjectManagerInterfacesAdded, PropertiesPropertiesChanged,
 };
-use dbus::{Message, MessageType};
+use dbus::Message;
 
 use super::{AdapterId, CharacteristicId, DeviceId};
 
@@ -74,7 +74,7 @@ impl BluetoothEvent {
         let mut events = vec![];
         // Return events for PropertiesChanged signals.
         if let Some(properties_changed) = PropertiesPropertiesChanged::from_message(&message) {
-            let object_path = message.path().unwrap().to_string();
+            let object_path = message.path().unwrap().into_static();
             log::trace!(
                 "PropertiesChanged for {}: {:?}",
                 object_path,
@@ -127,12 +127,8 @@ impl BluetoothEvent {
             }
         } else if let Some(interfaces_added) = ObjectManagerInterfacesAdded::from_message(&message)
         {
-            let object_path = interfaces_added.object.to_string();
-            log::trace!(
-                "InterfacesAdded for {}: {:#?}",
-                object_path,
-                interfaces_added
-            );
+            log::trace!("InterfacesAdded: {:#?}", interfaces_added);
+            let object_path = interfaces_added.object;
             if let Some(_device) = interfaces_added.interfaces.get("org.bluez.Device1") {
                 let id = DeviceId { object_path };
                 events.push(BluetoothEvent::Device {

--- a/mijia/src/bluetooth/mod.rs
+++ b/mijia/src/bluetooth/mod.rs
@@ -13,6 +13,7 @@ use bluez_generated::{
 use dbus::arg::{RefArg, Variant};
 use dbus::nonblock::stdintf::org_freedesktop_dbus::{Introspectable, ObjectManager, Properties};
 use dbus::nonblock::{Proxy, SyncConnection};
+use dbus::Path;
 use futures::stream::{self, StreamExt};
 use futures::{FutureExt, Stream};
 use itertools::Itertools;
@@ -62,13 +63,13 @@ pub enum SpawnError {
 /// Opaque identifier for a Bluetooth adapter on the system.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct AdapterId {
-    pub(crate) object_path: String,
+    pub(crate) object_path: Path<'static>,
 }
 
 impl AdapterId {
     pub(crate) fn new(object_path: &str) -> Self {
         Self {
-            object_path: object_path.to_owned(),
+            object_path: object_path.to_owned().into(),
         }
     }
 }
@@ -78,13 +79,13 @@ impl AdapterId {
 /// will also happen from that adapter (in case the system has more than one).
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct DeviceId {
-    pub(crate) object_path: String,
+    pub(crate) object_path: Path<'static>,
 }
 
 impl DeviceId {
     pub(crate) fn new(object_path: &str) -> Self {
         Self {
-            object_path: object_path.to_owned(),
+            object_path: object_path.to_owned().into(),
         }
     }
 
@@ -101,13 +102,13 @@ impl DeviceId {
 /// Opaque identifier for a GATT service on a Bluetooth device.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct ServiceId {
-    pub(crate) object_path: String,
+    pub(crate) object_path: Path<'static>,
 }
 
 impl ServiceId {
     pub(crate) fn new(object_path: &str) -> Self {
         Self {
-            object_path: object_path.to_owned(),
+            object_path: object_path.to_owned().into(),
         }
     }
 
@@ -124,14 +125,14 @@ impl ServiceId {
 /// Opaque identifier for a GATT characteristic on a Bluetooth device.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct CharacteristicId {
-    pub(crate) object_path: String,
+    pub(crate) object_path: Path<'static>,
 }
 
 impl CharacteristicId {
     #[cfg(test)]
     pub(crate) fn new(object_path: &str) -> Self {
         Self {
-            object_path: object_path.to_owned(),
+            object_path: object_path.to_owned().into(),
         }
     }
 
@@ -298,7 +299,7 @@ impl BluetoothSession {
 
         let sensors = tree
             .into_iter()
-            .filter_map(|(path, interfaces)| {
+            .filter_map(|(object_path, interfaces)| {
                 // FIXME: can we generate a strongly typed deserialiser for this,
                 // based on the introspection data?
                 let device_properties = interfaces.get("org.bluez.Device1")?;
@@ -320,9 +321,7 @@ impl BluetoothSession {
                 let service_data = get_service_data(device_properties).unwrap_or_default();
 
                 Some(DeviceInfo {
-                    id: DeviceId {
-                        object_path: path.to_string(),
-                    },
+                    id: DeviceId { object_path },
                     mac_address: MacAddress(mac_address),
                     name,
                     service_data,
@@ -345,7 +344,7 @@ impl BluetoothSession {
             let subnode_name = subnode.name.as_ref().unwrap();
             if subnode_name.starts_with("service") {
                 let service_id = ServiceId {
-                    object_path: format!("{}/{}", device.object_path, subnode_name),
+                    object_path: format!("{}/{}", device.object_path, subnode_name).into(),
                 };
                 let service = self.service(&service_id);
                 let uuid = Uuid::parse_str(&service.uuid().compat().await?)?;
@@ -371,7 +370,7 @@ impl BluetoothSession {
             let subnode_name = subnode.name.as_ref().unwrap();
             if subnode_name.starts_with("char") {
                 let characteristic_id = CharacteristicId {
-                    object_path: format!("{}/{}", service.object_path, subnode_name),
+                    object_path: format!("{}/{}", service.object_path, subnode_name).into(),
                 };
                 let uuid = Uuid::parse_str(
                     &self

--- a/mijia/src/lib.rs
+++ b/mijia/src/lib.rs
@@ -376,20 +376,32 @@ impl MijiaSession {
         id: &DeviceId,
     ) -> Result<Vec<Option<HistoryRecord>>, MijiaError> {
         let history_range = self.get_history_range(&id).await?;
-        // TODO: Get event stream that is filtered by D-Bus.
-        let events = self.event_stream().await?;
+
+        let history_record_characteristic = self
+            .bt_session
+            .get_service_characteristic_by_uuid(
+                id,
+                SERVICE_UUID,
+                HISTORY_RECORDS_CHARACTERISTIC_UUID,
+            )
+            .await?;
+        let events = self
+            .bt_session
+            .characteristic_event_stream(&history_record_characteristic.id)
+            .await?;
         let mut events = events.timeout(HISTORY_RECORD_TIMEOUT);
         self.start_notify_history(&id, Some(0)).await?;
 
         let mut history = vec![None; history_range.len()];
         while let Some(Ok(event)) = events.next().await {
             match event {
-                MijiaEvent::HistoryRecord {
+                BluetoothEvent::Characteristic {
                     id: record_id,
-                    record,
+                    event: CharacteristicEvent::Value { value },
                 } => {
+                    let record = HistoryRecord::decode(&value)?;
                     log::trace!("{:?}: {}", record_id, record);
-                    if record_id == *id {
+                    if record_id == history_record_characteristic.id {
                         if history_range.contains(&record.index) {
                             let offset = record.index - history_range.start;
                             history[offset as usize] = Some(record);
@@ -402,7 +414,7 @@ impl MijiaSession {
                             );
                         }
                     } else {
-                        log::warn!("Got record for wrong sensor {:?}", record_id);
+                        log::warn!("Got record for wrong characteristic {:?}", record_id);
                     }
                 }
                 _ => log::info!("Event: {:?}", event),


### PR DESCRIPTION
I've also done a bit of tidying up of the event parsing, added tests for the match rules, and added the ability to get a stream of events for a particular device or characteristic. This allows a TODO in `get_all_history` to be fixed.