### PR TITLE
Upgrade to Tokio 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -917,7 +917,7 @@ dependencies = [
  "serde_derive",
  "stable-eyre",
  "tokio 0.3.6",
- "tokio-compat-02 0.1.2",
+ "tokio-compat-02",
  "toml",
  "url",
 ]
@@ -1263,7 +1263,6 @@ dependencies = [
  "serde_derive",
  "thiserror",
  "tokio 1.0.1",
- "tokio-compat-02 0.2.0",
  "tokio-stream",
  "uuid",
 ]
@@ -2145,7 +2144,7 @@ dependencies = [
  "serde",
  "thiserror",
  "tokio 0.3.6",
- "tokio-compat-02 0.1.2",
+ "tokio-compat-02",
  "tokio-rustls 0.21.1",
  "warp",
 ]
@@ -2707,20 +2706,6 @@ dependencies = [
  "pin-project-lite 0.1.11",
  "tokio 0.2.24",
  "tokio 0.3.6",
-]
-
-[[package]]
-name = "tokio-compat-02"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d4237822b7be8fff0a7a27927462fad435dcb6650f95cea9e946bf6bdc7e07"
-dependencies = [
- "bytes 0.5.6",
- "once_cell",
- "pin-project-lite 0.2.0",
- "tokio 0.2.24",
- "tokio 1.0.1",
- "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,18 +130,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "async_io_stream"
-version = "0.2.0-beta.1"
+name = "async-tungstenite"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6b37d9496a9ae87767dce984e17f99a275937f0db1c2297db5f8465417964"
+checksum = "f7cc5408453d37e2b1c6f01d8078af1da58b6cfa6a80fa2ede3bd2b9a6ada9c4"
+dependencies = [
+ "futures-io",
+ "futures-util",
+ "log",
+ "pin-project 1.0.2",
+ "tokio 1.0.1",
+ "tokio-rustls 0.22.0",
+ "tungstenite",
+ "webpki-roots",
+]
+
+[[package]]
+name = "async_io_stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46cec760ddd264e11b5f7cf73bc74fb985d2b12a9cf2729590a2457e125a1afd"
 dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
  "futures-task",
  "pharos",
- "rustc_version 0.2.3",
- "tokio 0.3.6",
+ "rustc_version",
+ "tokio 1.0.1",
 ]
 
 [[package]]
@@ -305,6 +321,12 @@ name = "bytes"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
+
+[[package]]
+name = "bytes"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad1f8e949d755f9d79112b5bb46938e0ef9d3804a0b16dfab13aafcaa5f0fa72"
 
 [[package]]
 name = "cache-padded"
@@ -876,7 +898,7 @@ dependencies = [
  "homie-device",
  "log",
  "pretty_env_logger",
- "rumqttc",
+ "rumqttc 0.3.0",
  "rumqttd",
  "thiserror",
  "tokio 0.3.6",
@@ -893,10 +915,10 @@ dependencies = [
  "log",
  "mac_address",
  "pretty_env_logger",
- "rand 0.7.3",
- "rumqttc",
+ "rand 0.8.1",
+ "rumqttc 0.4.0",
  "thiserror",
- "tokio 0.3.6",
+ "tokio 1.0.1",
 ]
 
 [[package]]
@@ -910,14 +932,14 @@ dependencies = [
  "influx_db_client",
  "log",
  "pretty_env_logger",
- "rumqttc",
+ "rumqttc 0.3.0",
  "rustls 0.18.1",
- "rustls-native-certs",
+ "rustls-native-certs 0.4.0",
  "serde",
  "serde_derive",
  "stable-eyre",
  "tokio 0.3.6",
- "tokio-compat-02",
+ "tokio-compat-02 0.1.2",
  "toml",
  "url",
 ]
@@ -1281,13 +1303,14 @@ dependencies = [
  "log",
  "mijia",
  "pretty_env_logger",
- "rumqttc",
- "rustls 0.18.1",
- "rustls-native-certs",
+ "rumqttc 0.4.0",
+ "rustls 0.19.0",
+ "rustls-native-certs 0.5.0",
  "serde",
  "serde_derive",
  "stable-eyre",
- "tokio 0.3.6",
+ "tokio 1.0.1",
+ "tokio-compat-02 0.2.0",
  "toml",
 ]
 
@@ -1378,6 +1401,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15988061c9e6feb86fdb7cc01df1ede5a8bd765ebf9f085fe3f13751e6ea95af"
 dependencies = [
  "bytes 0.6.0",
+]
+
+[[package]]
+name = "mqttbytes"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9b7801639a5398353b9acf0764907d6571ca92e6b7a3662013b03861789449c"
+dependencies = [
+ "bytes 1.0.0",
 ]
 
 [[package]]
@@ -1877,6 +1909,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c24fcd450d3fa2b592732565aa4f17a27a61c65ece4726353e000939b0edee34"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.1",
+ "rand_hc 0.3.0",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1894,6 +1938,16 @@ checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.1",
 ]
 
 [[package]]
@@ -1921,6 +1975,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+dependencies = [
+ "getrandom 0.2.0",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1936,6 +1999,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core 0.6.1",
 ]
 
 [[package]]
@@ -2111,7 +2183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "789768b6459731a20055b85f3babb5335172082df6757a4e2c1131b78811314c"
 dependencies = [
  "async-channel",
- "async-tungstenite",
+ "async-tungstenite 0.10.0",
  "bytes 0.6.0",
  "http",
  "log",
@@ -2120,6 +2192,26 @@ dependencies = [
  "thiserror",
  "tokio 0.3.6",
  "tokio-rustls 0.20.0",
+ "webpki",
+ "ws_stream_tungstenite",
+]
+
+[[package]]
+name = "rumqttc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce595f8458fc85e4fd25838395d8ceda6591b61691e7ed6d9becfea5f8c4334"
+dependencies = [
+ "async-channel",
+ "async-tungstenite 0.11.0",
+ "bytes 1.0.0",
+ "http",
+ "log",
+ "mqttbytes",
+ "pollster",
+ "thiserror",
+ "tokio 1.0.1",
+ "tokio-rustls 0.22.0",
  "webpki",
  "ws_stream_tungstenite",
 ]
@@ -2144,7 +2236,7 @@ dependencies = [
  "serde",
  "thiserror",
  "tokio 0.3.6",
- "tokio-compat-02",
+ "tokio-compat-02 0.1.2",
  "tokio-rustls 0.21.1",
  "warp",
 ]
@@ -2187,20 +2279,11 @@ checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
 
 [[package]]
 name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65c94201b44764d6d1f7e37c15a8289ed55e546c1762c7f1d57f616966e0c181"
 dependencies = [
- "semver 0.11.0",
+ "semver",
 ]
 
 [[package]]
@@ -2239,6 +2322,18 @@ dependencies = [
  "rustls 0.18.1",
  "schannel",
  "security-framework 1.0.0",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+dependencies = [
+ "openssl-probe",
+ "rustls 0.19.0",
+ "schannel",
+ "security-framework 2.0.0",
 ]
 
 [[package]]
@@ -2345,27 +2440,12 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser 0.7.0",
-]
-
-[[package]]
-name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
- "semver-parser 0.10.1",
+ "semver-parser",
 ]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "semver-parser"
@@ -2688,11 +2768,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d258221f566b6c803c7b4714abadc080172b272090cdc5e244a6d4dd13c3a6bd"
 dependencies = [
  "autocfg 1.0.1",
+ "bytes 1.0.0",
  "libc",
+ "memchr",
  "mio 0.7.7",
  "num_cpus",
+ "once_cell",
+ "parking_lot",
  "pin-project-lite 0.2.0",
+ "signal-hook-registry",
  "tokio-macros 1.0.0",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2706,6 +2792,20 @@ dependencies = [
  "pin-project-lite 0.1.11",
  "tokio 0.2.24",
  "tokio 0.3.6",
+]
+
+[[package]]
+name = "tokio-compat-02"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7d4237822b7be8fff0a7a27927462fad435dcb6650f95cea9e946bf6bdc7e07"
+dependencies = [
+ "bytes 0.5.6",
+ "once_cell",
+ "pin-project-lite 0.2.0",
+ "tokio 0.2.24",
+ "tokio 1.0.1",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -2749,6 +2849,17 @@ checksum = "609ada6f5bf21315925c6e43d78dc51fba5c5968a995f95345b4781cc06f37eb"
 dependencies = [
  "rustls 0.19.0",
  "tokio 0.3.6",
+ "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+dependencies = [
+ "rustls 0.19.0",
+ "tokio 1.0.1",
  "webpki",
 ]
 
@@ -3206,11 +3317,11 @@ dependencies = [
 
 [[package]]
 name = "ws_stream_tungstenite"
-version = "0.4.0-beta.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62244813d35cc1bc2a24f84b2f0abdb4841ffcb8798622d589383cde28586b43"
+checksum = "36ebc1820b89be41eed8b792412dd06504444eec65d6b598b71e322de86e2902"
 dependencies = [
- "async-tungstenite",
+ "async-tungstenite 0.11.0",
  "async_io_stream",
  "bitflags",
  "futures-core",
@@ -3218,8 +3329,8 @@ dependencies = [
  "futures-sink",
  "log",
  "pharos",
- "rustc_version 0.3.0",
- "tokio 0.3.6",
+ "rustc_version",
+ "tokio 1.0.1",
  "tungstenite",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,9 +460,9 @@ dependencies = [
 
 [[package]]
 name = "dbus"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22c08adfeb70c940c14d8af988fa854dcb5529e6141f2397e4e0fa4c9375d094"
+checksum = "3b1334c0161ddfccd239ac81b188d62015b049c986c5cd0b7f9447cf2c54f4a3"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -472,14 +472,13 @@ dependencies = [
 
 [[package]]
 name = "dbus-tokio"
-version = "0.6.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6840421e249bf51f6ad1873b53f7423f14e712208792dfe4b3a8ff99f713309"
+checksum = "8b4083ad3ad374032aaacf18c4cce2c65c3ba5d4e576a037339a8b6cd0b4509c"
 dependencies = [
  "dbus",
  "libc",
- "mio 0.6.23",
- "tokio 0.2.24",
+ "tokio 1.0.1",
 ]
 
 [[package]]
@@ -918,7 +917,7 @@ dependencies = [
  "serde_derive",
  "stable-eyre",
  "tokio 0.3.6",
- "tokio-compat-02",
+ "tokio-compat-02 0.1.2",
  "toml",
  "url",
 ]
@@ -1263,8 +1262,9 @@ dependencies = [
  "serde-xml-rs",
  "serde_derive",
  "thiserror",
- "tokio 0.3.6",
- "tokio-compat-02",
+ "tokio 1.0.1",
+ "tokio-compat-02 0.2.0",
+ "tokio-stream",
  "uuid",
 ]
 
@@ -2145,7 +2145,7 @@ dependencies = [
  "serde",
  "thiserror",
  "tokio 0.3.6",
- "tokio-compat-02",
+ "tokio-compat-02 0.1.2",
  "tokio-rustls 0.21.1",
  "warp",
 ]
@@ -2658,7 +2658,6 @@ dependencies = [
  "num_cpus",
  "pin-project-lite 0.1.11",
  "slab",
- "tokio-macros 0.2.6",
 ]
 
 [[package]]
@@ -2684,6 +2683,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d258221f566b6c803c7b4714abadc080172b272090cdc5e244a6d4dd13c3a6bd"
+dependencies = [
+ "autocfg 1.0.1",
+ "libc",
+ "mio 0.7.7",
+ "num_cpus",
+ "pin-project-lite 0.2.0",
+ "tokio-macros 1.0.0",
+]
+
+[[package]]
 name = "tokio-compat-02"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2697,10 +2710,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-macros"
-version = "0.2.6"
+name = "tokio-compat-02"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
+checksum = "e7d4237822b7be8fff0a7a27927462fad435dcb6650f95cea9e946bf6bdc7e07"
+dependencies = [
+ "bytes 0.5.6",
+ "once_cell",
+ "pin-project-lite 0.2.0",
+ "tokio 0.2.24",
+ "tokio 1.0.1",
+ "tokio-stream",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46dfffa59fc3c8aad216ed61bdc2c263d2b9d87a9c8ac9de0c11a813e51b6db7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2709,9 +2736,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "0.3.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46dfffa59fc3c8aad216ed61bdc2c263d2b9d87a9c8ac9de0c11a813e51b6db7"
+checksum = "42517d2975ca3114b22a16192634e8241dc5cc1f130be194645970cc1c371494"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2738,6 +2765,17 @@ dependencies = [
  "rustls 0.19.0",
  "tokio 0.3.6",
  "webpki",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4cdeb73537e63f98adcd73138af75e3f368ccaecffaa29d7eb61b9f5a440457"
+dependencies = [
+ "futures-core",
+ "pin-project-lite 0.2.0",
+ "tokio 1.0.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,22 +115,6 @@ dependencies = [
 
 [[package]]
 name = "async-tungstenite"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39eca8dd578b18e557361e50ca767df55c5e62f690a5e53868c3c7a8123145b7"
-dependencies = [
- "futures-io",
- "futures-util",
- "log",
- "pin-project 1.0.2",
- "tokio 0.3.6",
- "tokio-rustls 0.20.0",
- "tungstenite",
- "webpki-roots",
-]
-
-[[package]]
-name = "async-tungstenite"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7cc5408453d37e2b1c6f01d8078af1da58b6cfa6a80fa2ede3bd2b9a6ada9c4"
@@ -140,7 +124,7 @@ dependencies = [
  "log",
  "pin-project 1.0.2",
  "tokio 1.0.1",
- "tokio-rustls 0.22.0",
+ "tokio-rustls",
  "tungstenite",
  "webpki-roots",
 ]
@@ -318,12 +302,6 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
-
-[[package]]
-name = "bytes"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad1f8e949d755f9d79112b5bb46938e0ef9d3804a0b16dfab13aafcaa5f0fa72"
@@ -413,29 +391,13 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "core-foundation"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
-dependencies = [
- "core-foundation-sys 0.7.0",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
 dependencies = [
- "core-foundation-sys 0.8.2",
+ "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "core-foundation-sys"
@@ -898,10 +860,10 @@ dependencies = [
  "homie-device",
  "log",
  "pretty_env_logger",
- "rumqttc 0.3.0",
+ "rumqttc",
  "rumqttd",
  "thiserror",
- "tokio 0.3.6",
+ "tokio 1.0.1",
  "toml",
 ]
 
@@ -916,7 +878,7 @@ dependencies = [
  "mac_address",
  "pretty_env_logger",
  "rand 0.8.1",
- "rumqttc 0.4.0",
+ "rumqttc",
  "thiserror",
  "tokio 1.0.1",
 ]
@@ -932,14 +894,14 @@ dependencies = [
  "influx_db_client",
  "log",
  "pretty_env_logger",
- "rumqttc 0.3.0",
- "rustls 0.18.1",
- "rustls-native-certs 0.4.0",
+ "rumqttc",
+ "rustls",
+ "rustls-native-certs",
  "serde",
  "serde_derive",
  "stable-eyre",
- "tokio 0.3.6",
- "tokio-compat-02 0.1.2",
+ "tokio 1.0.1",
+ "tokio-compat-02 0.2.0",
  "toml",
  "url",
 ]
@@ -1303,9 +1265,9 @@ dependencies = [
  "log",
  "mijia",
  "pretty_env_logger",
- "rumqttc 0.4.0",
- "rustls 0.19.0",
- "rustls-native-certs 0.5.0",
+ "rumqttc",
+ "rustls",
+ "rustls-native-certs",
  "serde",
  "serde_derive",
  "stable-eyre",
@@ -1395,15 +1357,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mqtt4bytes"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15988061c9e6feb86fdb7cc01df1ede5a8bd765ebf9f085fe3f13751e6ea95af"
-dependencies = [
- "bytes 0.6.0",
-]
-
-[[package]]
 name = "mqttbytes"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1449,8 +1402,8 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework 2.0.0",
- "security-framework-sys 2.0.0",
+ "security-framework",
+ "security-framework-sys",
  "tempfile",
 ]
 
@@ -2178,32 +2131,12 @@ dependencies = [
 
 [[package]]
 name = "rumqttc"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789768b6459731a20055b85f3babb5335172082df6757a4e2c1131b78811314c"
-dependencies = [
- "async-channel",
- "async-tungstenite 0.10.0",
- "bytes 0.6.0",
- "http",
- "log",
- "mqtt4bytes",
- "pollster",
- "thiserror",
- "tokio 0.3.6",
- "tokio-rustls 0.20.0",
- "webpki",
- "ws_stream_tungstenite",
-]
-
-[[package]]
-name = "rumqttc"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dce595f8458fc85e4fd25838395d8ceda6591b61691e7ed6d9becfea5f8c4334"
 dependencies = [
  "async-channel",
- "async-tungstenite 0.11.0",
+ "async-tungstenite",
  "bytes 1.0.0",
  "http",
  "log",
@@ -2211,49 +2144,49 @@ dependencies = [
  "pollster",
  "thiserror",
  "tokio 1.0.1",
- "tokio-rustls 0.22.0",
+ "tokio-rustls",
  "webpki",
  "ws_stream_tungstenite",
 ]
 
 [[package]]
 name = "rumqttd"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd5ff299e27e4bd470139b4fa876e76b9009f6ab50ec2afdf100d9c8abf57ac"
+checksum = "d82464aa70ef15371d86c30ba575b6cb03bdea9a61047b6eda97c5d91bece675"
 dependencies = [
  "argh",
- "bytes 0.6.0",
+ "bytes 1.0.0",
  "confy",
  "ctrlc",
  "jemallocator",
  "log",
- "mqtt4bytes",
+ "mqttbytes",
  "pprof",
  "pretty_env_logger",
  "prost",
  "rumqttlog",
  "serde",
  "thiserror",
- "tokio 0.3.6",
+ "tokio 1.0.1",
  "tokio-compat-02 0.1.2",
- "tokio-rustls 0.21.1",
+ "tokio-rustls",
  "warp",
 ]
 
 [[package]]
 name = "rumqttlog"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511614a9d7cd219b50c5db91bb0847b17b1586ec561af672037a82e13e1643fd"
+checksum = "3d7614d9650a8ad14ddf022c94f8dcb7b8c149d7f77b18dbebe7fee77886f546"
 dependencies = [
  "byteorder",
- "bytes 0.6.0",
+ "bytes 1.0.0",
  "fnv",
  "jackiechan",
  "log",
  "memmap",
- "mqtt4bytes",
+ "mqttbytes",
  "segments",
  "serde",
  "thiserror",
@@ -2288,19 +2221,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
-dependencies = [
- "base64 0.12.3",
- "log",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064fd21ff87c6e87ed4506e68beb42459caa4a0e2eb144932e6776768556980b"
@@ -2314,26 +2234,14 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629d439a7672da82dd955498445e496ee2096fe2117b9f796558a43fdb9e59b8"
-dependencies = [
- "openssl-probe",
- "rustls 0.18.1",
- "schannel",
- "security-framework 1.0.0",
-]
-
-[[package]]
-name = "rustls-native-certs"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
 dependencies = [
  "openssl-probe",
- "rustls 0.19.0",
+ "rustls",
  "schannel",
- "security-framework 2.0.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -2382,38 +2290,15 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad502866817f0575705bd7be36e2b2535cc33262d493aa733a2ec862baa2bc2b"
-dependencies = [
- "bitflags",
- "core-foundation 0.7.0",
- "core-foundation-sys 0.7.0",
- "libc",
- "security-framework-sys 1.0.0",
-]
-
-[[package]]
-name = "security-framework"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1759c2e3c8580017a484a7ac56d3abc5a6c1feadf88db2f3633f12ae4268c69"
 dependencies = [
  "bitflags",
- "core-foundation 0.9.1",
- "core-foundation-sys 0.8.2",
+ "core-foundation",
+ "core-foundation-sys",
  "libc",
- "security-framework-sys 2.0.0",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ceb04988b17b6d1dcd555390fa822ca5637b4a14e1f5099f13d351bed4d6c7"
-dependencies = [
- "core-foundation-sys 0.7.0",
- "libc",
+ "security-framework-sys",
 ]
 
 [[package]]
@@ -2422,7 +2307,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f99b9d5e26d2a71633cc4f2ebae7cc9f874044e0c351a27e17892d76dce5678b"
 dependencies = [
- "core-foundation-sys 0.8.2",
+ "core-foundation-sys",
  "libc",
 ]
 
@@ -2746,19 +2631,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "720ba21c25078711bf456d607987d95bce90f7c3bea5abe1db587862e7a1e87c"
 dependencies = [
  "autocfg 1.0.1",
- "bytes 0.6.0",
  "futures-core",
- "libc",
- "memchr",
- "mio 0.7.7",
- "num_cpus",
- "once_cell",
- "parking_lot",
  "pin-project-lite 0.2.0",
- "signal-hook-registry",
- "slab",
- "tokio-macros 0.3.2",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2777,7 +2651,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite 0.2.0",
  "signal-hook-registry",
- "tokio-macros 1.0.0",
+ "tokio-macros",
  "winapi 0.3.9",
 ]
 
@@ -2810,17 +2684,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46dfffa59fc3c8aad216ed61bdc2c263d2b9d87a9c8ac9de0c11a813e51b6db7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tokio-macros"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42517d2975ca3114b22a16192634e8241dc5cc1f130be194645970cc1c371494"
@@ -2832,33 +2695,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3f045b4a15afc543ffe6e02bae7ecf372e89a0f9f8c4b15b13f0ceed4f105"
-dependencies = [
- "rustls 0.18.1",
- "tokio 0.3.6",
- "webpki",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609ada6f5bf21315925c6e43d78dc51fba5c5968a995f95345b4781cc06f37eb"
-dependencies = [
- "rustls 0.19.0",
- "tokio 0.3.6",
- "webpki",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
- "rustls 0.19.0",
+ "rustls",
  "tokio 1.0.1",
  "webpki",
 ]
@@ -3321,7 +3162,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36ebc1820b89be41eed8b792412dd06504444eec65d6b598b71e322de86e2902"
 dependencies = [
- "async-tungstenite 0.11.0",
+ "async-tungstenite",
  "async_io_stream",
  "bitflags",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,9 +862,9 @@ dependencies = [
  "pretty_env_logger",
  "rumqttc",
  "rumqttd",
+ "rumqttlog",
  "thiserror",
  "tokio 1.0.1",
- "toml",
 ]
 
 [[package]]

--- a/bluez-generated/Cargo.toml
+++ b/bluez-generated/Cargo.toml
@@ -13,4 +13,4 @@ categories = ["api-bindings", "os::linux-apis"]
 maintenance = { status = "experimental" }
 
 [dependencies]
-dbus = { version = "0.9.0", features = ["futures"] }
+dbus = { version = "0.9.1", features = ["futures"] }

--- a/homie-controller/Cargo.toml
+++ b/homie-controller/Cargo.toml
@@ -11,14 +11,14 @@ categories = ["network-programming"]
 
 [dependencies]
 log = "0.4.11"
-rumqttc = "0.3.0"
-thiserror = "1.0.22"
+rumqttc = "0.4.0"
+thiserror = "1.0.23"
 
 [dev-dependencies]
 async-channel = "1.5.1"
 futures = "0.3.8"
 homie-device = { version = "0.3.1", path = "../homie-device" }
 pretty_env_logger = "0.4.0"
-rumqttd = "0.2.0"
-tokio = "0.3.6"
-toml = "0.5.7"
+rumqttd = "0.3.0"
+tokio = { version = "1.0.1", features = ["macros", "rt", "rt-multi-thread", "time"] }
+toml = "0.5.8"

--- a/homie-controller/Cargo.toml
+++ b/homie-controller/Cargo.toml
@@ -20,5 +20,5 @@ futures = "0.3.8"
 homie-device = { version = "0.3.1", path = "../homie-device" }
 pretty_env_logger = "0.4.0"
 rumqttd = "0.3.0"
+rumqttlog = "0.4.0"
 tokio = { version = "1.0.1", features = ["macros", "rt", "rt-multi-thread", "time"] }
-toml = "0.5.8"

--- a/homie-device/Cargo.toml
+++ b/homie-device/Cargo.toml
@@ -15,10 +15,11 @@ futures = "0.3.8"
 local_ipaddress = "0.1.3"
 log = "0.4.11"
 mac_address = "1.1.1"
-rumqttc = "0.3.0"
-tokio = "0.3.6"
-thiserror = "1.0.22"
+rumqttc = "0.4.0"
+tokio = "1.0.1"
+thiserror = "1.0.23"
 
 [dev-dependencies]
 pretty_env_logger = "0.4.0"
-rand = "0.7.3"
+rand = "0.8.1"
+tokio = { version = "1.0.1", features = ["macros", "rt", "rt-multi-thread", "time"] }

--- a/homie-device/src/lib.rs
+++ b/homie-device/src/lib.rs
@@ -175,12 +175,12 @@ impl HomieDeviceBuilder {
         Option<UpdateCallback>,
     ) {
         let mut mqtt_options = self.mqtt_options;
-        let mut last_will = LastWill::new(
+        let last_will = LastWill::new(
             format!("{}/$state", self.device_base),
-            QoS::AtLeastOnce,
             State::Lost,
+            QoS::AtLeastOnce,
+            true,
         );
-        last_will.retain = true;
         mqtt_options.set_last_will(last_will);
         let (client, event_loop) = AsyncClient::new(mqtt_options, REQUESTS_CAP);
 

--- a/homie-influx/Cargo.toml
+++ b/homie-influx/Cargo.toml
@@ -17,16 +17,16 @@ homie-controller = { version = "0.2.0", path = "../homie-controller" }
 influx_db_client = "0.4.5"
 log = "0.4.11"
 pretty_env_logger = "0.4.0"
-rumqttc = "0.3.0"
-rustls = "0.18.1"
-rustls-native-certs = "0.4.0"
+rumqttc = "0.4.0"
+rustls = "0.19.0"
+rustls-native-certs = "0.5.0"
 serde_derive = "1.0.118"
 serde = "1.0.118"
 stable-eyre = "0.2.1"
-tokio = "0.3.6"
+tokio = "1.0.1"
 toml = "0.5.8"
 url = { version = "2.2.0", features = ["serde"] }
-tokio-compat-02 = "0.1.2"
+tokio-compat-02 = "0.2.0"
 
 [package.metadata.deb]
 # $auto doesn't work because we don't build packages in the same container as we build the binaries.

--- a/mijia-homie/Cargo.toml
+++ b/mijia-homie/Cargo.toml
@@ -20,13 +20,14 @@ itertools = "0.10.0"
 log = "0.4.11"
 mijia = { version = "0.2.0", path = "../mijia" }
 pretty_env_logger = "0.4.0"
-rumqttc = "0.3.0"
-rustls = "0.18.1"
-rustls-native-certs = "0.4.0"
+rumqttc = "0.4.0"
+rustls = "0.19.0"
+rustls-native-certs = "0.5.0"
 serde_derive = "1.0.118"
 serde = "1.0.118"
 stable-eyre = "0.2.1"
-tokio = "0.3.6"
+tokio = { version = "1.0.1", features = ["macros", "rt-multi-thread"] }
+tokio-compat-02 = "0.2.0"
 toml = "0.5.7"
 
 [package.metadata.deb]

--- a/mijia-homie/src/main.rs
+++ b/mijia-homie/src/main.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
 use tokio::{time, try_join};
+use tokio_compat_02::FutureExt;
 
 const SCAN_INTERVAL: Duration = Duration::from_secs(15);
 const CONNECT_INTERVAL: Duration = Duration::from_secs(1);
@@ -417,6 +418,7 @@ async fn connect_and_subscribe_sensor_or_disconnect(
             .wrap_err_with(|| format!("Disconnecting from {} ({})", name, id))?;
         Err(Report::new(e).wrap_err(format!("Starting notifications on {} ({})", name, id)))
     })
+    .compat()
     .await?;
 
     Ok(id)

--- a/mijia/Cargo.toml
+++ b/mijia/Cargo.toml
@@ -13,21 +13,22 @@ categories = ["hardware-support"]
 async-trait = "0.1.42"
 bitflags = "1.2.1"
 bluez-generated = { version = "0.2.0", path = "../bluez-generated" }
-dbus = { version = "0.9.0", features = ["futures"] }
-dbus-tokio = "0.6.0"
+dbus = { version = "0.9.1", features = ["futures"] }
+dbus-tokio = "0.7.3"
 futures = "0.3.8"
 itertools = "0.10.0"
 log = "0.4.11"
 serde = "1.0.118"
 serde_derive = "1.0.118"
 serde-xml-rs = "0.4.0"
-thiserror = "1.0.22"
-tokio = "0.3.6"
-tokio-compat-02 = "0.1.2"
+thiserror = "1.0.23"
+tokio = "1.0.1"
+tokio-compat-02 = "0.2.0"
+tokio-stream = "0.1.1"
 uuid = "0.8.1"
 
 [dev-dependencies]
 chrono = "0.4.19"
 eyre = "0.6.3"
 pretty_env_logger = "0.4.0"
-tokio = { version = "0.3.6", features = ["macros", "rt", "rt-multi-thread", "time"] }
+tokio = { version = "1.0.1", features = ["macros", "rt", "rt-multi-thread", "time"] }

--- a/mijia/Cargo.toml
+++ b/mijia/Cargo.toml
@@ -23,7 +23,6 @@ serde_derive = "1.0.118"
 serde-xml-rs = "0.4.0"
 thiserror = "1.0.23"
 tokio = "1.0.1"
-tokio-compat-02 = "0.2.0"
 tokio-stream = "0.1.1"
 uuid = "0.8.1"
 

--- a/mijia/examples/readings.rs
+++ b/mijia/examples/readings.rs
@@ -4,8 +4,8 @@ use eyre::Report;
 use mijia::{MijiaEvent, MijiaSession, SensorProps};
 use std::process::exit;
 use std::time::Duration;
-use tokio::stream::StreamExt;
 use tokio::time;
+use tokio_stream::StreamExt;
 
 const SCAN_DURATION: Duration = Duration::from_secs(5);
 

--- a/mijia/src/bluetooth/messagestream.rs
+++ b/mijia/src/bluetooth/messagestream.rs
@@ -5,7 +5,6 @@ use futures::Stream;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
-use tokio_compat_02::FutureExt as _;
 
 /// Wrapper for a stream of D-Bus messages which automatically removes the `MsgMatch` from the D-Bus
 /// connection when it is dropped.
@@ -38,12 +37,6 @@ impl Drop for MessageStream {
     fn drop(&mut self) {
         let connection = self.connection.clone();
         let msg_match = self.msg_match.take().unwrap();
-        tokio::spawn(async move {
-            connection
-                .remove_match(msg_match.token())
-                .compat()
-                .await
-                .unwrap()
-        });
+        tokio::spawn(async move { connection.remove_match(msg_match.token()).await.unwrap() });
     }
 }

--- a/mijia/src/bluetooth/mod.rs
+++ b/mijia/src/bluetooth/mod.rs
@@ -29,7 +29,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
 use tokio::task::JoinError;
-use tokio_compat_02::FutureExt as _;
 use uuid::Uuid;
 
 const DBUS_METHOD_CALL_TIMEOUT: Duration = Duration::from_secs(30);
@@ -425,7 +424,7 @@ impl BluetoothSession {
         // The resource is a task that should be spawned onto a tokio compatible
         // reactor ASAP. If the resource ever finishes, you lost connection to D-Bus.
         let dbus_handle = tokio::spawn(async {
-            let err = dbus_resource.compat().await;
+            let err = dbus_resource.await;
             Err(SpawnError::DbusConnectionLost(err))
         });
         Ok((
@@ -442,7 +441,7 @@ impl BluetoothSession {
             DBUS_METHOD_CALL_TIMEOUT,
             self.connection.clone(),
         );
-        let tree = bluez_root.get_managed_objects().compat().await?;
+        let tree = bluez_root.get_managed_objects().await?;
         let adapters: Vec<_> = tree
             .into_iter()
             .filter_map(|(path, interfaces)| interfaces.get("org.bluez.Adapter1").map(|_| path))
@@ -460,10 +459,9 @@ impl BluetoothSession {
                 DBUS_METHOD_CALL_TIMEOUT,
                 self.connection.clone(),
             );
-            adapter.set_powered(true).compat().await?;
+            adapter.set_powered(true).await?;
             adapter
                 .start_discovery()
-                .compat()
                 .await
                 .unwrap_or_else(|err| println!("starting discovery failed {:?}", err));
         }
@@ -478,7 +476,7 @@ impl BluetoothSession {
             DBUS_METHOD_CALL_TIMEOUT,
             self.connection.clone(),
         );
-        let tree = bluez_root.get_managed_objects().compat().await?;
+        let tree = bluez_root.get_managed_objects().await?;
 
         let sensors = tree
             .into_iter()
@@ -521,7 +519,7 @@ impl BluetoothSession {
         &self,
         device: &DeviceId,
     ) -> Result<Vec<ServiceInfo>, BluetoothError> {
-        let device_node = self.device(device).introspect_parse().compat().await?;
+        let device_node = self.device(device).introspect_parse().await?;
         let mut services = vec![];
         for subnode in device_node.nodes {
             let subnode_name = subnode.name.as_ref().unwrap();
@@ -532,8 +530,8 @@ impl BluetoothSession {
                     object_path: format!("{}/{}", device.object_path, subnode_name).into(),
                 };
                 let service = self.service(&service_id);
-                let uuid = Uuid::parse_str(&service.uuid().compat().await?)?;
-                let primary = service.primary().compat().await?;
+                let uuid = Uuid::parse_str(&service.uuid().await?)?;
+                let primary = service.primary().await?;
                 services.push(ServiceInfo {
                     id: service_id,
                     uuid,
@@ -549,7 +547,7 @@ impl BluetoothSession {
         &self,
         service: &ServiceId,
     ) -> Result<Vec<CharacteristicInfo>, BluetoothError> {
-        let service_node = self.service(service).introspect_parse().compat().await?;
+        let service_node = self.service(service).introspect_parse().await?;
         let mut characteristics = vec![];
         for subnode in service_node.nodes {
             let subnode_name = subnode.name.as_ref().unwrap();
@@ -560,8 +558,8 @@ impl BluetoothSession {
                     object_path: format!("{}/{}", service.object_path, subnode_name).into(),
                 };
                 let characteristic = self.characteristic(&characteristic_id);
-                let uuid = Uuid::parse_str(&characteristic.uuid().compat().await?)?;
-                let flags = characteristic.flags().compat().await?;
+                let uuid = Uuid::parse_str(&characteristic.uuid().await?)?;
+                let flags = characteristic.flags().await?;
                 characteristics.push(CharacteristicInfo {
                     id: characteristic_id,
                     uuid,
@@ -580,7 +578,6 @@ impl BluetoothSession {
         let characteristic_node = self
             .characteristic(characteristic)
             .introspect_parse()
-            .compat()
             .await?;
         let mut descriptors = vec![];
         for subnode in characteristic_node.nodes {
@@ -591,8 +588,7 @@ impl BluetoothSession {
                 let descriptor_id = DescriptorId {
                     object_path: format!("{}/{}", characteristic.object_path, subnode_name).into(),
                 };
-                let uuid =
-                    Uuid::parse_str(&self.descriptor(&descriptor_id).uuid().compat().await?)?;
+                let uuid = Uuid::parse_str(&self.descriptor(&descriptor_id).uuid().await?)?;
                 descriptors.push(DescriptorInfo {
                     id: descriptor_id,
                     uuid,
@@ -649,8 +645,8 @@ impl BluetoothSession {
     /// Get information about the given GATT service.
     pub async fn get_service_info(&self, id: &ServiceId) -> Result<ServiceInfo, BluetoothError> {
         let service = self.service(&id);
-        let uuid = Uuid::parse_str(&service.uuid().compat().await?)?;
-        let primary = service.primary().compat().await?;
+        let uuid = Uuid::parse_str(&service.uuid().await?)?;
+        let primary = service.primary().await?;
         Ok(ServiceInfo {
             id: id.to_owned(),
             uuid,
@@ -664,8 +660,8 @@ impl BluetoothSession {
         id: &CharacteristicId,
     ) -> Result<CharacteristicInfo, BluetoothError> {
         let characteristic = self.characteristic(&id);
-        let uuid = Uuid::parse_str(&characteristic.uuid().compat().await?)?;
-        let flags = characteristic.flags().compat().await?;
+        let uuid = Uuid::parse_str(&characteristic.uuid().await?)?;
+        let flags = characteristic.flags().await?;
         Ok(CharacteristicInfo {
             id: id.to_owned(),
             uuid,
@@ -678,7 +674,7 @@ impl BluetoothSession {
         &self,
         id: &DescriptorId,
     ) -> Result<DescriptorInfo, BluetoothError> {
-        let uuid = Uuid::parse_str(&self.descriptor(&id).uuid().compat().await?)?;
+        let uuid = Uuid::parse_str(&self.descriptor(&id).uuid().await?)?;
         Ok(DescriptorInfo {
             id: id.to_owned(),
             uuid,
@@ -729,12 +725,12 @@ impl BluetoothSession {
 
     /// Connect to the Bluetooth device with the given D-Bus object path.
     pub async fn connect(&self, id: &DeviceId) -> Result<(), BluetoothError> {
-        Ok(self.device(id).connect().compat().await?)
+        Ok(self.device(id).connect().await?)
     }
 
     /// Disconnect from the Bluetooth device with the given D-Bus object path.
     pub async fn disconnect(&self, id: &DeviceId) -> Result<(), BluetoothError> {
-        Ok(self.device(id).disconnect().compat().await?)
+        Ok(self.device(id).disconnect().await?)
     }
 
     /// Read the value of the given GATT characteristic.
@@ -743,7 +739,7 @@ impl BluetoothSession {
         id: &CharacteristicId,
     ) -> Result<Vec<u8>, BluetoothError> {
         let characteristic = self.characteristic(id);
-        Ok(characteristic.read_value(HashMap::new()).compat().await?)
+        Ok(characteristic.read_value(HashMap::new()).await?)
     }
 
     /// Write the given value to the given GATT characteristic.
@@ -755,7 +751,6 @@ impl BluetoothSession {
         let characteristic = self.characteristic(id);
         Ok(characteristic
             .write_value(value.into(), HashMap::new())
-            .compat()
             .await?)
     }
 
@@ -765,7 +760,7 @@ impl BluetoothSession {
         id: &DescriptorId,
     ) -> Result<Vec<u8>, BluetoothError> {
         let descriptor = self.descriptor(id);
-        Ok(descriptor.read_value(HashMap::new()).compat().await?)
+        Ok(descriptor.read_value(HashMap::new()).await?)
     }
 
     /// Write the given value to the given GATT descriptor.
@@ -775,23 +770,20 @@ impl BluetoothSession {
         value: impl Into<Vec<u8>>,
     ) -> Result<(), BluetoothError> {
         let descriptor = self.descriptor(id);
-        Ok(descriptor
-            .write_value(value.into(), HashMap::new())
-            .compat()
-            .await?)
+        Ok(descriptor.write_value(value.into(), HashMap::new()).await?)
     }
 
     /// Start notifications on the given GATT characteristic.
     pub async fn start_notify(&self, id: &CharacteristicId) -> Result<(), BluetoothError> {
         let characteristic = self.characteristic(id);
-        characteristic.start_notify().compat().await?;
+        characteristic.start_notify().await?;
         Ok(())
     }
 
     /// Stop notifications on the given GATT characteristic.
     pub async fn stop_notify(&self, id: &CharacteristicId) -> Result<(), BluetoothError> {
         let characteristic = self.characteristic(id);
-        characteristic.stop_notify().compat().await?;
+        characteristic.stop_notify().await?;
         Ok(())
     }
 
@@ -822,7 +814,7 @@ impl BluetoothSession {
     ) -> Result<impl Stream<Item = BluetoothEvent>, BluetoothError> {
         let mut message_streams = vec![];
         for match_rule in BluetoothEvent::match_rules(object.cloned()) {
-            let msg_match = self.connection.add_match(match_rule).compat().await?;
+            let msg_match = self.connection.add_match(match_rule).await?;
             message_streams.push(MessageStream::new(msg_match, self.connection.clone()));
         }
         Ok(select_all(message_streams)

--- a/mijia/src/bluetooth/mod.rs
+++ b/mijia/src/bluetooth/mod.rs
@@ -16,12 +16,12 @@ use dbus::arg::{RefArg, Variant};
 use dbus::nonblock::stdintf::org_freedesktop_dbus::{Introspectable, ObjectManager, Properties};
 use dbus::nonblock::{Proxy, SyncConnection};
 use dbus::Path;
+use dbus_tokio::connection::IOResourceError;
 use futures::stream::{self, select_all, StreamExt};
 use futures::{FutureExt, Stream};
 use itertools::Itertools;
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
-use std::error::Error;
 use std::fmt::{self, Debug, Display, Formatter};
 use std::future::Future;
 use std::str::FromStr;
@@ -58,10 +58,10 @@ pub enum BluetoothError {
 }
 
 /// Error type for futures representing tasks spawned by this crate.
-#[derive(Error, Debug)]
+#[derive(Debug, Error)]
 pub enum SpawnError {
     #[error("D-Bus connection lost: {0}")]
-    DbusConnectionLost(#[source] Box<dyn Error + Send + Sync>),
+    DbusConnectionLost(#[source] IOResourceError),
     #[error("Task failed: {0}")]
     Join(#[from] JoinError),
 }

--- a/mijia/src/lib.rs
+++ b/mijia/src/lib.rs
@@ -5,7 +5,8 @@ use futures::Stream;
 use std::ops::Range;
 use std::time::{Duration, SystemTime};
 use thiserror::Error;
-use tokio::stream::StreamExt;
+use tokio::pin;
+use tokio_stream::StreamExt;
 use uuid::Uuid;
 
 pub mod bluetooth;
@@ -389,7 +390,8 @@ impl MijiaSession {
             .bt_session
             .characteristic_event_stream(&history_record_characteristic.id)
             .await?;
-        let mut events = events.timeout(HISTORY_RECORD_TIMEOUT);
+        let events = events.timeout(HISTORY_RECORD_TIMEOUT);
+        pin!(events);
         self.start_notify_history(&id, Some(0)).await?;
 
         let mut history = vec![None; history_range.len()];


### PR DESCRIPTION
This includes some changes to work with the latest versions of the `dbus-tokio`, `rumqttc` and `rumqttd` crates.