### PR TITLE
Run Rust and Lint workflows on all pull requests.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master]
 
 env:
   dbus-codegen-version: 0.9.0

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
There's no reason to limit them to pull requests for master, as we often create chains of dependent PRs.