### PR TITLE
Updating version numbers ready for release.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "homie-influx"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "color-backtrace",
  "eyre",
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "mijia-homie"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "backoff",
  "color-backtrace",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "bluez-generated"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dbus",
 ]
@@ -577,9 +577,9 @@ checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 
 [[package]]
 name = "eyre"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f29abf4740a4778632fe27a4f681ef5b7a6f659aeba3330ac66f48e20cfa3b7"
+checksum = "221239d1d5ea86bf5d6f91c9d6bc3646ffe471b08ff9b0f91c44f115ac969d2b"
 dependencies = [
  "indenter",
  "once_cell",
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "homie-controller"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-channel",
  "futures",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "homie-device"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "async-channel",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1251,7 +1251,7 @@ dependencies = [
 
 [[package]]
 name = "mijia"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bluez-async",
  "chrono",

--- a/bluez-async/Cargo.toml
+++ b/bluez-async/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["api-bindings", "hardware-support", "os::linux-apis"]
 [dependencies]
 async-trait = "0.1.42"
 bitflags = "1.2.1"
-bluez-generated = { version = "0.2.0", path = "../bluez-generated" }
+bluez-generated = { version = "0.2.1", path = "../bluez-generated" }
 dbus = { version = "0.9.1", features = ["futures"] }
 dbus-tokio = "0.7.3"
 futures = "0.3.8"
@@ -26,6 +26,6 @@ tokio = "1.0.1"
 uuid = "0.8.1"
 
 [dev-dependencies]
-eyre = "0.6.3"
+eyre = "0.6.5"
 pretty_env_logger = "0.4.0"
 tokio = { version = "1.0.1", features = ["macros", "rt", "rt-multi-thread", "time"] }

--- a/bluez-generated/Cargo.toml
+++ b/bluez-generated/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bluez-generated"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Andrew Walbran <qwandor@google.com>", "David Laban <alsuren@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/homie-controller/Cargo.toml
+++ b/homie-controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "homie-controller"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Andrew Walbran <qwandor@google.com>", "David Laban <alsuren@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -17,7 +17,7 @@ thiserror = "1.0.23"
 [dev-dependencies]
 async-channel = "1.5.1"
 futures = "0.3.8"
-homie-device = { version = "0.3.1", path = "../homie-device" }
+homie-device = { version = "0.4.0", path = "../homie-device" }
 pretty_env_logger = "0.4.0"
 rumqttd = "0.3.0"
 rumqttlog = "0.4.0"

--- a/homie-device/Cargo.toml
+++ b/homie-device/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "homie-device"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Andrew Walbran <qwandor@google.com>", "David Laban <alsuren@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/homie-influx/Cargo.toml
+++ b/homie-influx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "homie-influx"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Andrew Walbran <qwandor@google.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/homie-influx/Cargo.toml
+++ b/homie-influx/Cargo.toml
@@ -11,9 +11,9 @@ categories = ["network-programming"]
 
 [dependencies]
 color-backtrace = "0.5.0"
-eyre = "0.6.3"
+eyre = "0.6.5"
 futures = "0.3.8"
-homie-controller = { version = "0.2.0", path = "../homie-controller" }
+homie-controller = { version = "0.3.0", path = "../homie-controller" }
 influx_db_client = "0.4.5"
 log = "0.4.11"
 pretty_env_logger = "0.4.0"

--- a/mijia-homie/Cargo.toml
+++ b/mijia-homie/Cargo.toml
@@ -18,7 +18,7 @@ futures-channel = "0.3.8"
 homie-device = { version = "0.4.0", path = "../homie-device" }
 itertools = "0.10.0"
 log = "0.4.11"
-mijia = { version = "0.2.0", path = "../mijia" }
+mijia = { version = "0.3.0", path = "../mijia" }
 pretty_env_logger = "0.4.0"
 rumqttc = "0.4.0"
 rustls = "0.19.0"

--- a/mijia-homie/Cargo.toml
+++ b/mijia-homie/Cargo.toml
@@ -12,10 +12,10 @@ categories = ["network-programming"]
 [dependencies]
 backoff = { version = "0.2.1", features = ["tokio"] }
 color-backtrace = "0.5.0"
-eyre = "0.6.3"
+eyre = "0.6.5"
 futures = "0.3.8"
 futures-channel = "0.3.8"
-homie-device = { version = "0.3.1", path = "../homie-device" }
+homie-device = { version = "0.4.0", path = "../homie-device" }
 itertools = "0.10.0"
 log = "0.4.11"
 mijia = { version = "0.2.0", path = "../mijia" }
@@ -28,7 +28,7 @@ serde = "1.0.118"
 stable-eyre = "0.2.1"
 tokio = { version = "1.0.1", features = ["macros", "rt-multi-thread"] }
 tokio-compat-02 = "0.2.0"
-toml = "0.5.7"
+toml = "0.5.8"
 
 [package.metadata.deb]
 # $auto doesn't work because we don't build packages in the same container as we build the binaries.

--- a/mijia-homie/Cargo.toml
+++ b/mijia-homie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mijia-homie"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["David Laban <alsuren@gmail.com>", "Andrew Walbran <qwandor@google.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/mijia/Cargo.toml
+++ b/mijia/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mijia"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Luis Félix <lcs.felix@gmail.com>", "Andrew Walbran <qwandor@google.com>", "David Laban <alsuren@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/mijia/Cargo.toml
+++ b/mijia/Cargo.toml
@@ -20,6 +20,6 @@ uuid = "0.8.1"
 
 [dev-dependencies]
 chrono = "0.4.19"
-eyre = "0.6.3"
+eyre = "0.6.5"
 pretty_env_logger = "0.4.0"
 tokio = { version = "1.0.1", features = ["macros", "rt", "rt-multi-thread", "time"] }


### PR DESCRIPTION
We can release new versions of all the crates, with Tokio 1.0 and all the other changes.