### PR TITLE
Increment version numbers for releasing bluez-async and mijia.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "bluez-async"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -1251,7 +1251,7 @@ dependencies = [
 
 [[package]]
 name = "mijia"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bluez-async",
  "chrono",

--- a/bluez-async/Cargo.toml
+++ b/bluez-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bluez-async"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Andrew Walbran <qwandor@google.com>", "David Laban <alsuren@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/mijia-homie/Cargo.toml
+++ b/mijia-homie/Cargo.toml
@@ -18,7 +18,7 @@ futures-channel = "0.3.8"
 homie-device = { version = "0.4.0", path = "../homie-device" }
 itertools = "0.10.0"
 log = "0.4.11"
-mijia = { version = "0.3.0", path = "../mijia" }
+mijia = { version = "0.3.1", path = "../mijia" }
 pretty_env_logger = "0.4.0"
 rumqttc = "0.4.0"
 rustls = "0.19.0"

--- a/mijia/Cargo.toml
+++ b/mijia/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mijia"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Luis Félix <lcs.felix@gmail.com>", "Andrew Walbran <qwandor@google.com>", "David Laban <alsuren@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -10,7 +10,7 @@ keywords = ["ble", "bluetooth", "humidity", "temperature"]
 categories = ["hardware-support"]
 
 [dependencies]
-bluez-async = { version = "0.1.0", path = "../bluez-async" }
+bluez-async = { version = "0.1.1", path = "../bluez-async" }
 futures = "0.3.8"
 log = "0.4.11"
 thiserror = "1.0.23"


### PR DESCRIPTION
This lets us get the improved README onto crates.io, as well as the extra fields on `DeviceInfo`.