### PR TITLE
Go back to building cross Docker images from Debian.

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -2,8 +2,7 @@
 # Based on https://www.collabora.com/news-and-blog/blog/2020/06/23/cross-building-rust-gstreamer-plugins-for-the-raspberry-pi/
 # but with `RUN apt-get install -y libdbus-1-dev:armhf` thrown in to get the dependency we need.
 # This image has been pushed to dockerhub.
-image = "ghcr.io/qwandor/cross-dbus-debian-buster-armv7:latest"
-
+image = "ghcr.io/qwandor/cross-dbus-debian-buster-armv7:0.2.1"
 
 # Once https://github.com/rust-embedded/cross/pull/446 gets somewhere, you
 # will be able to use `context` and `dockerfile` to achieve the same result.
@@ -14,13 +13,13 @@ image = "ghcr.io/qwandor/cross-dbus-debian-buster-armv7:latest"
 # dockerfile = "./docker/Dockerfile.debian-buster-armv7"
 
 [target.aarch64-unknown-linux-gnu]
-image = "ghcr.io/qwandor/cross-dbus-debian-buster-aarch64:latest"
+image = "ghcr.io/qwandor/cross-dbus-debian-buster-aarch64:0.2.1"
 
 # context = "./docker"
 # dockerfile = "./docker/Dockerfile.debian-buster-aarch64"
 
 [target.x86_64-unknown-linux-gnu]
-image = "ghcr.io/qwandor/cross-dbus-debian-buster-x86_64:latest"
+image = "ghcr.io/qwandor/cross-dbus-debian-buster-x86_64:0.2.1"
 
 # context = "./docker"
 # dockerfile = "./docker/Dockerfile.debian-buster-x86_64"

--- a/Cross.toml
+++ b/Cross.toml
@@ -2,7 +2,7 @@
 # Based on https://www.collabora.com/news-and-blog/blog/2020/06/23/cross-building-rust-gstreamer-plugins-for-the-raspberry-pi/
 # but with `RUN apt-get install -y libdbus-1-dev:armhf` thrown in to get the dependency we need.
 # This image has been pushed to dockerhub.
-image = "alsuren/cross-dbus:armv7-unknown-linux-gnu-0.2.1"
+image = "ghcr.io/qwandor/cross-dbus-debian-buster-armv7:latest"
 
 
 # Once https://github.com/rust-embedded/cross/pull/446 gets somewhere, you
@@ -11,16 +11,16 @@ image = "alsuren/cross-dbus:armv7-unknown-linux-gnu-0.2.1"
 # cargo install --git=https://github.com/alsuren/cross --branch=docker-build-context
 # and then comment out `image`, above and uncomment the following two lines:
 # context = "./docker"
-# dockerfile = "./docker/Dockerfile.dbus.armv7-unknown-linux-gnueabihf"
+# dockerfile = "./docker/Dockerfile.debian-buster-armv7"
 
 [target.aarch64-unknown-linux-gnu]
-image = "alsuren/cross-dbus:aarch64-unknown-linux-gnu-0.2.1"
+image = "ghcr.io/qwandor/cross-dbus-debian-buster-aarch64:latest"
 
 # context = "./docker"
-# dockerfile = "./docker/Dockerfile.dbus.aarch64-unknown-linux-gnu"
+# dockerfile = "./docker/Dockerfile.debian-buster-aarch64"
 
 [target.x86_64-unknown-linux-gnu]
-image = "alsuren/cross-dbus:x86_64-unknown-linux-gnu-0.2.1"
+image = "ghcr.io/qwandor/cross-dbus-debian-buster-x86_64:latest"
 
 # context = "./docker"
-# dockerfile = "./docker/Dockerfile.dbus.x86_64-unknown-linux-gnu"
+# dockerfile = "./docker/Dockerfile.debian-buster-x86_64"

--- a/docker/Dockerfile.dbus.aarch64-unknown-linux-gnu
+++ b/docker/Dockerfile.dbus.aarch64-unknown-linux-gnu
@@ -1,7 +1,0 @@
-FROM rustembedded/cross:aarch64-unknown-linux-gnu-0.2.1
-
-RUN dpkg --add-architecture arm64 && \
-    apt-get update && \
-    apt-get install -y libssl-dev:arm64 libdbus-1-dev:arm64
-
-ENV PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig

--- a/docker/Dockerfile.dbus.armv7-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.dbus.armv7-unknown-linux-gnueabihf
@@ -1,7 +1,0 @@
-FROM rustembedded/cross:armv7-unknown-linux-gnueabihf-0.2.1
-
-RUN dpkg --add-architecture armhf && \
-    apt-get update && \
-    apt-get install -y libssl-dev:armhf libdbus-1-dev:armhf
-
-ENV PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabihf/pkgconfig

--- a/docker/Dockerfile.dbus.x86_64-unknown-linux-gnu
+++ b/docker/Dockerfile.dbus.x86_64-unknown-linux-gnu
@@ -1,4 +1,0 @@
-FROM rustembedded/cross:x86_64-unknown-linux-gnu-0.2.1
-
-RUN apt-get update && \
-    apt-get install -y libssl-dev libdbus-1-dev

--- a/docker/Dockerfile.debian-buster-aarch64
+++ b/docker/Dockerfile.debian-buster-aarch64
@@ -1,5 +1,5 @@
 # Built from https://github.com/qwandor/cross/blob/context/docker/Dockerfile.context
-FROM ghcr.io/qwandor/cross-context:latest as context
+FROM ghcr.io/qwandor/cross-context:0.2.1 as context
 
 FROM debian:buster
 

--- a/docker/Dockerfile.debian-buster-aarch64
+++ b/docker/Dockerfile.debian-buster-aarch64
@@ -1,3 +1,4 @@
+# Built from https://github.com/qwandor/cross/blob/context/docker/Dockerfile.context
 FROM ghcr.io/qwandor/cross-context:latest as context
 
 FROM debian:buster

--- a/docker/Dockerfile.debian-buster-aarch64
+++ b/docker/Dockerfile.debian-buster-aarch64
@@ -1,0 +1,27 @@
+FROM ghcr.io/qwandor/cross-context:latest as context
+
+FROM debian:buster
+
+COPY --from=context common.sh lib.sh /
+RUN /common.sh
+
+COPY --from=context cmake.sh /
+RUN /cmake.sh
+
+COPY --from=context xargo.sh /
+RUN /xargo.sh
+
+RUN apt-get install --assume-yes --no-install-recommends \
+	g++-aarch64-linux-gnu \
+	libc6-dev-arm64-cross
+
+RUN dpkg --add-architecture arm64 && \
+	apt-get update && \
+	apt-get install -y libssl-dev:arm64 libdbus-1-dev:arm64
+
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+	CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
+	CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++ \
+	QEMU_LD_PREFIX=/usr/aarch64-linux-gnu \
+	RUST_TEST_THREADS=1 \
+	PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig

--- a/docker/Dockerfile.debian-buster-armv7
+++ b/docker/Dockerfile.debian-buster-armv7
@@ -1,5 +1,5 @@
 # Built from https://github.com/qwandor/cross/blob/context/docker/Dockerfile.context
-FROM ghcr.io/qwandor/cross-context:latest as context
+FROM ghcr.io/qwandor/cross-context:0.2.1 as context
 
 FROM debian:buster
 

--- a/docker/Dockerfile.debian-buster-armv7
+++ b/docker/Dockerfile.debian-buster-armv7
@@ -1,3 +1,4 @@
+# Built from https://github.com/qwandor/cross/blob/context/docker/Dockerfile.context
 FROM ghcr.io/qwandor/cross-context:latest as context
 
 FROM debian:buster

--- a/docker/Dockerfile.debian-buster-armv7
+++ b/docker/Dockerfile.debian-buster-armv7
@@ -1,0 +1,27 @@
+FROM ghcr.io/qwandor/cross-context:latest as context
+
+FROM debian:buster
+
+COPY --from=context common.sh lib.sh /
+RUN /common.sh
+
+COPY --from=context cmake.sh /
+RUN /cmake.sh
+
+COPY --from=context xargo.sh /
+RUN /xargo.sh
+
+RUN apt-get install --assume-yes --no-install-recommends \
+	g++-arm-linux-gnueabihf \
+	libc6-dev-armhf-cross
+
+RUN dpkg --add-architecture armhf && \
+	apt-get update && \
+	apt-get install -y libssl-dev:armhf libdbus-1-dev:armhf
+
+ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
+	CC_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-gcc \
+	CXX_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-g++ \
+	QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf \
+	RUST_TEST_THREADS=1 \
+	PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabihf/pkgconfig

--- a/docker/Dockerfile.debian-buster-x86_64
+++ b/docker/Dockerfile.debian-buster-x86_64
@@ -1,5 +1,5 @@
 # Built from https://github.com/qwandor/cross/blob/context/docker/Dockerfile.context
-FROM ghcr.io/qwandor/cross-context:latest as context
+FROM ghcr.io/qwandor/cross-context:0.2.1 as context
 
 FROM debian:buster
 

--- a/docker/Dockerfile.debian-buster-x86_64
+++ b/docker/Dockerfile.debian-buster-x86_64
@@ -1,3 +1,4 @@
+# Built from https://github.com/qwandor/cross/blob/context/docker/Dockerfile.context
 FROM ghcr.io/qwandor/cross-context:latest as context
 
 FROM debian:buster

--- a/docker/Dockerfile.debian-buster-x86_64
+++ b/docker/Dockerfile.debian-buster-x86_64
@@ -1,0 +1,15 @@
+FROM ghcr.io/qwandor/cross-context:latest as context
+
+FROM debian:buster
+
+COPY --from=context common.sh lib.sh /
+RUN /common.sh
+
+COPY --from=context cmake.sh /
+RUN /cmake.sh
+
+COPY --from=context xargo.sh /
+RUN /xargo.sh
+
+RUN apt-get update && \
+	apt-get install -y libssl-dev libdbus-1-dev

--- a/docker/update.sh
+++ b/docker/update.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+docker build ./docker -f docker/Dockerfile.debian-buster-aarch64 \
+    -t ghcr.io/qwandor/cross-dbus-debian-buster-aarch64:latest
+docker build ./docker -f docker/Dockerfile.debian-buster-armv7 \
+    -t ghcr.io/qwandor/cross-dbus-debian-buster-armv7:latest
+docker build ./docker -f docker/Dockerfile.debian-buster-x86_64 \
+    -t ghcr.io/qwandor/cross-dbus-debian-buster-x86_64:latest
+
+docker push ghcr.io/qwandor/cross-dbus-debian-buster-aarch64:latest
+docker push ghcr.io/qwandor/cross-dbus-debian-buster-armv7:latest
+docker push ghcr.io/qwandor/cross-dbus-debian-buster-x86_64:latest

--- a/docker/update.sh
+++ b/docker/update.sh
@@ -2,13 +2,15 @@
 
 set -euo pipefail
 
-docker build ./docker -f docker/Dockerfile.debian-buster-aarch64 \
-    -t ghcr.io/qwandor/cross-dbus-debian-buster-aarch64:latest
-docker build ./docker -f docker/Dockerfile.debian-buster-armv7 \
-    -t ghcr.io/qwandor/cross-dbus-debian-buster-armv7:latest
-docker build ./docker -f docker/Dockerfile.debian-buster-x86_64 \
-    -t ghcr.io/qwandor/cross-dbus-debian-buster-x86_64:latest
+VERSION=0.2.1
 
-docker push ghcr.io/qwandor/cross-dbus-debian-buster-aarch64:latest
-docker push ghcr.io/qwandor/cross-dbus-debian-buster-armv7:latest
-docker push ghcr.io/qwandor/cross-dbus-debian-buster-x86_64:latest
+docker build ./docker -f docker/Dockerfile.debian-buster-aarch64 \
+    -t ghcr.io/qwandor/cross-dbus-debian-buster-aarch64:$VERSION
+docker build ./docker -f docker/Dockerfile.debian-buster-armv7 \
+    -t ghcr.io/qwandor/cross-dbus-debian-buster-armv7:$VERSION
+docker build ./docker -f docker/Dockerfile.debian-buster-x86_64 \
+    -t ghcr.io/qwandor/cross-dbus-debian-buster-x86_64:$VERSION
+
+docker push ghcr.io/qwandor/cross-dbus-debian-buster-aarch64:$VERSION
+docker push ghcr.io/qwandor/cross-dbus-debian-buster-armv7:$VERSION
+docker push ghcr.io/qwandor/cross-dbus-debian-buster-x86_64:$VERSION

--- a/homie-influx/Cargo.toml
+++ b/homie-influx/Cargo.toml
@@ -30,7 +30,7 @@ tokio-compat-02 = "0.2.0"
 
 [package.metadata.deb]
 # $auto doesn't work because we don't build packages in the same container as we build the binaries.
-depends = "adduser, libssl1.0.0, libc6"
+depends = "adduser, libssl1.1, libc6"
 section = "net"
 maintainer-scripts = "debian-scripts"
 conf-files = ["/etc/homie-influx/homie-influx.toml", "/etc/homie-influx/mappings.toml"]


### PR DESCRIPTION
Using an image based on the upstream cross images doesn't really work because they are based on an old version of Ubuntu, so we end up linking against the wrong version of libssl.

Fixes #125, by essentially reverting #102.