### PR TITLE
Add manufacturer data to DeviceInfo, and add new DeviceEvent variant

### DIFF
--- a/bluez-async/README.md
+++ b/bluez-async/README.md
@@ -20,6 +20,7 @@ let (_, session) = BluetoothSession::new().await?;
 // Start scanning for Bluetooth devices, and wait a few seconds for some to be discovered.
 session.start_discovery().await?;
 time::sleep(Duration::from_secs(5)).await;
+session.stop_discovery().await?;
 
 // Get a list of devices which are currently known.
 let devices = session.get_devices().await?;

--- a/bluez-async/examples/characteristics.rs
+++ b/bluez-async/examples/characteristics.rs
@@ -1,3 +1,6 @@
+//! Example to dump information about the services and characteristics of all devices for which we
+//! know them, i.e. connected devices.
+
 use bluez_async::{BleUuid, BluetoothSession, CharacteristicFlags};
 use std::ops::RangeInclusive;
 use std::str;

--- a/bluez-async/examples/devices.rs
+++ b/bluez-async/examples/devices.rs
@@ -13,6 +13,7 @@ async fn main() -> Result<(), eyre::Report> {
     // Start scanning for Bluetooth devices, and wait a while for some to be discovered.
     session.start_discovery().await?;
     time::sleep(SCAN_DURATION).await;
+    session.stop_discovery().await?;
 
     // Get the list of all devices which BlueZ knows about.
     let devices = session.get_devices().await?;

--- a/bluez-async/examples/devices.rs
+++ b/bluez-async/examples/devices.rs
@@ -1,3 +1,5 @@
+//! Example to scan for a short time and then list all known devices.
+
 use bluez_async::BluetoothSession;
 use std::time::Duration;
 use tokio::time;

--- a/bluez-async/examples/events.rs
+++ b/bluez-async/examples/events.rs
@@ -1,3 +1,5 @@
+//! Example to log Bluetooth events, including duplicate manufacturer-specific advertisement data.
+
 use bluez_async::{BluetoothSession, DiscoveryFilter};
 use futures::stream::StreamExt;
 

--- a/bluez-async/examples/events.rs
+++ b/bluez-async/examples/events.rs
@@ -1,4 +1,4 @@
-use bluez_async::BluetoothSession;
+use bluez_async::{BluetoothSession, DiscoveryFilter};
 use futures::stream::StreamExt;
 
 #[tokio::main]
@@ -7,6 +7,12 @@ async fn main() -> Result<(), eyre::Report> {
 
     let (_, session) = BluetoothSession::new().await?;
     let mut events = session.event_stream().await?;
+    session
+        .start_discovery_with_filter(&DiscoveryFilter {
+            duplicate_data: Some(true),
+            ..DiscoveryFilter::default()
+        })
+        .await?;
 
     println!("Events:");
     while let Some(event) = events.next().await {

--- a/bluez-async/src/events.rs
+++ b/bluez-async/src/events.rs
@@ -7,8 +7,9 @@ use dbus::nonblock::stdintf::org_freedesktop_dbus::{
     ObjectManagerInterfacesAdded, PropertiesPropertiesChanged,
 };
 use dbus::{Message, Path};
+use std::collections::HashMap;
 
-use super::{AdapterId, CharacteristicId, DeviceId};
+use super::{convert_manufacturer_data, AdapterId, CharacteristicId, DeviceId};
 
 /// An event relating to a Bluetooth device or adapter.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -54,6 +55,10 @@ pub enum DeviceEvent {
     Connected { connected: bool },
     /// A new value is available for the RSSI of the device.
     RSSI { rssi: i16 },
+    /// A new value is available for the manufacturer-specific advertisement data of the device.
+    ManufacturerData {
+        manufacturer_data: HashMap<u16, Vec<u8>>,
+    },
 }
 
 /// Details of an event related to a GATT characteristic.
@@ -171,9 +176,17 @@ impl BluetoothEvent {
                 }
                 if let Some(rssi) = device.rssi() {
                     events.push(BluetoothEvent::Device {
-                        id,
+                        id: id.clone(),
                         event: DeviceEvent::RSSI { rssi },
                     });
+                }
+                if let Some(manufacturer_data) = device.manufacturer_data() {
+                    events.push(BluetoothEvent::Device {
+                        id,
+                        event: DeviceEvent::ManufacturerData {
+                            manufacturer_data: convert_manufacturer_data(manufacturer_data),
+                        },
+                    })
                 }
             }
             ORG_BLUEZ_GATT_CHARACTERISTIC1_NAME => {
@@ -198,7 +211,6 @@ impl BluetoothEvent {
 mod tests {
     use super::super::ServiceId;
     use dbus::arg::{RefArg, Variant};
-    use std::collections::HashMap;
 
     use super::*;
 
@@ -225,6 +237,24 @@ mod tests {
             vec![BluetoothEvent::Device {
                 id,
                 event: DeviceEvent::RSSI { rssi }
+            }]
+        )
+    }
+
+    #[test]
+    fn device_manufacturer_data() {
+        let mut manufacturer_data = HashMap::new();
+        manufacturer_data.insert(42, vec![1u8, 2, 3]);
+        let message = device_manufacturer_data_message(
+            "/org/bluez/hci0/dev_11_22_33_44_55_66",
+            manufacturer_data.clone(),
+        );
+        let id = DeviceId::new("/org/bluez/hci0/dev_11_22_33_44_55_66");
+        assert_eq!(
+            BluetoothEvent::message_to_events(message),
+            vec![BluetoothEvent::Device {
+                id,
+                event: DeviceEvent::ManufacturerData { manufacturer_data }
             }]
         )
     }
@@ -369,6 +399,27 @@ mod tests {
     fn device_rssi_message(device_path: &'static str, rssi: i16) -> Message {
         let mut changed_properties: HashMap<String, Variant<Box<dyn RefArg>>> = HashMap::new();
         changed_properties.insert("RSSI".to_string(), Variant(Box::new(rssi)));
+        let properties_changed = PropertiesPropertiesChanged {
+            interface_name: "org.bluez.Device1".to_string(),
+            changed_properties,
+            invalidated_properties: vec![],
+        };
+        properties_changed.to_emit_message(&device_path.into())
+    }
+
+    fn device_manufacturer_data_message(
+        device_path: &'static str,
+        manufacturer_data: HashMap<u16, Vec<u8>>,
+    ) -> Message {
+        let manufacturer_data: HashMap<_, _> = manufacturer_data
+            .into_iter()
+            .map::<(u16, Variant<Box<dyn RefArg>>), _>(|(k, v)| (k, Variant(Box::new(v))))
+            .collect();
+        let mut changed_properties: HashMap<String, Variant<Box<dyn RefArg>>> = HashMap::new();
+        changed_properties.insert(
+            "ManufacturerData".to_string(),
+            Variant(Box::new(manufacturer_data)),
+        );
         let properties_changed = PropertiesPropertiesChanged {
             interface_name: "org.bluez.Device1".to_string(),
             changed_properties,

--- a/bluez-async/src/events.rs
+++ b/bluez-async/src/events.rs
@@ -39,6 +39,7 @@ pub enum BluetoothEvent {
 
 /// Details of an event related to a Bluetooth adapter.
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum AdapterEvent {
     /// The adapter has been powered on or off.
     Powered { powered: bool },
@@ -48,6 +49,7 @@ pub enum AdapterEvent {
 
 /// Details of an event related to a Bluetooth device.
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum DeviceEvent {
     /// A new device has been discovered.
     Discovered,
@@ -63,6 +65,7 @@ pub enum DeviceEvent {
 
 /// Details of an event related to a GATT characteristic.
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum CharacteristicEvent {
     /// A new value of the characteristic has been received. This may be from a notification.
     Value { value: Vec<u8> },

--- a/bluez-async/src/lib.rs
+++ b/bluez-async/src/lib.rs
@@ -505,7 +505,7 @@ impl BluetoothSession {
         );
         let tree = bluez_root.get_managed_objects().await?;
 
-        let sensors = tree
+        let devices = tree
             .into_iter()
             .filter_map(|(object_path, interfaces)| {
                 let device_properties = OrgBluezDevice1Properties::from_interfaces(&interfaces)?;
@@ -531,7 +531,7 @@ impl BluetoothSession {
                 })
             })
             .collect();
-        Ok(sensors)
+        Ok(devices)
     }
 
     /// Get a list of all GATT services which the given Bluetooth device offers.

--- a/bluez-async/src/lib.rs
+++ b/bluez-async/src/lib.rs
@@ -799,12 +799,12 @@ impl BluetoothSession {
         )
     }
 
-    /// Connect to the Bluetooth device with the given D-Bus object path.
+    /// Connect to the given Bluetooth device.
     pub async fn connect(&self, id: &DeviceId) -> Result<(), BluetoothError> {
         Ok(self.device(id).connect().await?)
     }
 
-    /// Disconnect from the Bluetooth device with the given D-Bus object path.
+    /// Disconnect from the given Bluetooth device.
     pub async fn disconnect(&self, id: &DeviceId) -> Result<(), BluetoothError> {
         Ok(self.device(id).disconnect().await?)
     }

--- a/bluez-async/src/lib.rs
+++ b/bluez-async/src/lib.rs
@@ -555,7 +555,7 @@ impl Into<PropMap> for &DiscoveryFilter {
 /// from different places. It is the main entry point to the library.
 #[derive(Clone)]
 pub struct BluetoothSession {
-    pub connection: Arc<SyncConnection>,
+    connection: Arc<SyncConnection>,
 }
 
 impl Debug for BluetoothSession {


### PR DESCRIPTION
This does part of what is requested in #129.

Also adds new `get_device_info` and `stop_discovery` methods.