### PR TITLE
Helper example to add names to a config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,6 +1262,7 @@ dependencies = [
  "thiserror",
  "tokio 1.0.1",
  "tokio-stream",
+ "toml",
  "uuid",
 ]
 

--- a/mijia-homie/Cargo.toml
+++ b/mijia-homie/Cargo.toml
@@ -9,6 +9,14 @@ repository = "https://github.com/alsuren/mijia-homie/"
 keywords = ["ble", "bluetooth", "homie", "mqtt"]
 categories = ["network-programming"]
 
+[[bin]]
+name = "mijia-homie"
+path = "src/main.rs"
+
+[[bin]]
+name = "mijia-names"
+path = "src/mijia-names.rs"
+
 [dependencies]
 backoff = { version = "0.2.1", features = ["tokio"] }
 color-backtrace = "0.5.0"

--- a/mijia-homie/Cargo.toml
+++ b/mijia-homie/Cargo.toml
@@ -46,6 +46,7 @@ maintainer-scripts = "debian-scripts"
 conf-files = ["/etc/mijia-homie/mijia-homie.toml"]
 assets = [
 	["target/release/mijia-homie", "usr/bin/", "755"],
+	["target/release/mijia-names", "usr/bin/", "755"],
 	["mijia-homie.example.toml", "etc/mijia-homie/mijia-homie.toml", "640"],
 	["README.md", "usr/share/doc/mijia-homie/", "644"],
 ]

--- a/mijia-homie/src/mijia-names.rs
+++ b/mijia-homie/src/mijia-names.rs
@@ -87,6 +87,12 @@ async fn main() -> Result<(), Report> {
         }
     }
 
+    println!(
+        "Finished inspecting all known sensors.\n\n\
+        Some sensors may have been discovered while we were trying to inspect \
+        this batch. Re-run the program to also inspect these new sensors."
+    );
+
     Ok(())
 }
 

--- a/mijia-homie/src/mijia-names.rs
+++ b/mijia-homie/src/mijia-names.rs
@@ -57,6 +57,10 @@ async fn main() -> Result<(), Report> {
             let sensor_names_filename = sensor_names_filename.clone();
 
             tokio::task::spawn_blocking(move || {
+                println!(
+                    "Successfully connected to {} (it should now have a bluetooth icon on it)",
+                    sensor.mac_address
+                );
                 println!("What name do you want to use for {}?", sensor.mac_address);
                 let mut name = String::new();
                 stdin().read_line(&mut name)?;

--- a/mijia-homie/src/mijia-names.rs
+++ b/mijia-homie/src/mijia-names.rs
@@ -42,7 +42,8 @@ async fn main() -> Result<(), Report> {
     {
         println!("Connecting to {}", sensor.mac_address);
         if let Err(e) = session.bt_session.connect(&sensor.id).await {
-            println!("Failed to connect to {}: {:?}", sensor.mac_address, e);
+            println!("Failed to connect to {}", sensor.mac_address);
+            log::debug!("error was: {:?}", e);
 
             let mut file = OpenOptions::new()
                 .create(true)

--- a/mijia-homie/src/mijia-names.rs
+++ b/mijia-homie/src/mijia-names.rs
@@ -1,6 +1,6 @@
 //! Example of how to subscribe to readings from one or more sensors.
 
-use bluez_async::MacAddress;
+use mijia::bluetooth::MacAddress;
 use eyre::Report;
 use eyre::WrapErr;
 use mijia::{MijiaSession, SensorProps};

--- a/mijia-homie/src/mijia-names.rs
+++ b/mijia-homie/src/mijia-names.rs
@@ -1,8 +1,8 @@
 //! Example of how to subscribe to readings from one or more sensors.
 
-use mijia::bluetooth::MacAddress;
 use eyre::Report;
 use eyre::WrapErr;
+use mijia::bluetooth::MacAddress;
 use mijia::{MijiaSession, SensorProps};
 use std::collections::HashMap;
 use std::fs::OpenOptions;
@@ -13,20 +13,16 @@ use std::time::Duration;
 use tokio::time;
 
 const SCAN_DURATION: Duration = Duration::from_secs(5);
-const DEFAULT_SENSOR_NAMES_FILE: &str = "sensor-names.toml";
 
 #[tokio::main]
 async fn main() -> Result<(), Report> {
     pretty_env_logger::init();
 
     let args: Vec<String> = std::env::args().collect();
-    if args.len() > 2 {
-        eyre::bail!("USAGE: {} [/path/to/sensor-names.toml]", args[0]);
+    if args.len() != 2 {
+        eyre::bail!("USAGE: {} /path/to/sensor-names.toml", args[0]);
     }
-    let sensor_names_filename = args
-        .get(1)
-        .map(|s| s.to_owned())
-        .unwrap_or(DEFAULT_SENSOR_NAMES_FILE.to_owned());
+    let sensor_names_filename = args.get(1).map(|s| s.to_owned()).unwrap();
 
     let excludes = get_known_sensors(&sensor_names_filename)?;
     println!("ignoring sensors: {:?}", excludes);

--- a/mijia-homie/src/mijia-names.rs
+++ b/mijia-homie/src/mijia-names.rs
@@ -45,11 +45,7 @@ async fn main() -> Result<(), Report> {
             println!("Failed to connect to {}", sensor.mac_address);
             log::debug!("error was: {:?}", e);
 
-            let mut file = OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(&sensor_names_filename)?;
-            writeln!(file, r#""{mac}" = "failed""#, mac = sensor.mac_address,)?;
+            write_name(sensor_names_filename, sensor.mac_address, "failed");
             continue;
         }
 
@@ -67,21 +63,7 @@ async fn main() -> Result<(), Report> {
                 stdin().read_line(&mut name)?;
                 let name = name.trim_end();
 
-                let mut file = OpenOptions::new()
-                    .create(true)
-                    .append(true)
-                    .open(&sensor_names_filename)?;
-                writeln!(
-                    file,
-                    r#""{mac}" = "{name}""#,
-                    mac = sensor.mac_address,
-                    name = name
-                )?;
-                println!(
-                    r#"written: "{mac}" = "{name}""#,
-                    mac = sensor.mac_address,
-                    name = name
-                );
+                write_name(sensor_names_filename, sensor.mac_address, name);
                 Ok::<_, Report>(())
             })
             .await??;
@@ -99,6 +81,14 @@ async fn main() -> Result<(), Report> {
     );
 
     Ok(())
+}
+
+fn write_name(sensor_names_filename: &str, mac: &str, name: &str) {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&sensor_names_filename)?;
+    writeln!(file, r#""{mac}" = "{name}""#, mac = mac, name = name)?;
 }
 
 fn get_known_sensors(sensor_names_filename: &str) -> Result<Vec<MacAddress>, Report> {

--- a/mijia-homie/src/mijia-names.rs
+++ b/mijia-homie/src/mijia-names.rs
@@ -33,8 +33,8 @@ async fn main() -> Result<(), Report> {
     session.bt_session.start_discovery().await?;
     time::sleep(SCAN_DURATION).await;
 
-    // Get the list of sensors which are currently known, connect those which
-    // are not already known about.
+    // Get the list of sensors which are currently visible, connect those which
+    // are not already named.
     let sensors = session.get_sensors().await?;
     for sensor in sensors
         .iter()

--- a/mijia/Cargo.toml
+++ b/mijia/Cargo.toml
@@ -23,3 +23,4 @@ chrono = "0.4.19"
 eyre = "0.6.5"
 pretty_env_logger = "0.4.0"
 tokio = { version = "1.0.1", features = ["macros", "rt", "rt-multi-thread", "time"] }
+toml = "0.5.8"

--- a/mijia/examples/names.rs
+++ b/mijia/examples/names.rs
@@ -1,0 +1,79 @@
+//! Example of how to subscribe to readings from one or more sensors.
+
+use eyre::Report;
+use mijia::{MijiaEvent, MijiaSession, SensorProps};
+use std::process::exit;
+use std::time::Duration;
+use tokio::stream::StreamExt;
+use tokio::time;
+
+const SCAN_DURATION: Duration = Duration::from_secs(5);
+
+#[tokio::main]
+async fn main() -> Result<(), Report> {
+    pretty_env_logger::init();
+
+    let filters = parse_args()?;
+
+    let (_, session) = MijiaSession::new().await?;
+    let mut events = session.event_stream().await?;
+
+    // Start scanning for Bluetooth devices, and wait a while for some to be discovered.
+    session.bt_session.start_discovery().await?;
+    time::sleep(SCAN_DURATION).await;
+
+    // Get the list of sensors which are currently known, connect those which match the filter and
+    // subscribe to readings.
+    let sensors = session.get_sensors().await?;
+    println!("Sensors:");
+    for sensor in sensors
+        .iter()
+        .filter(|sensor| should_include_sensor(sensor, &filters))
+    {
+        println!("Connecting to {} ({:?})", sensor.mac_address, sensor.id);
+        if let Err(e) = session.bt_session.connect(&sensor.id).await {
+            println!("Failed to connect to {}: {:?}", sensor.mac_address, e);
+        } else {
+            session.start_notify_sensor(&sensor.id).await?;
+        }
+    }
+
+    println!("Readings:");
+    while let Some(event) = events.next().await {
+        match event {
+            MijiaEvent::Readings { id, readings } => {
+                println!("{:?}: {}", id, readings);
+            }
+            _ => println!("Event: {:?}", event),
+        }
+    }
+
+    Ok(())
+}
+
+fn parse_args() -> Result<Vec<String>, Report> {
+    // If at least one command-line argument is given, we will only try to connect to sensors whose
+    // MAC address containts one of them as a sub-string.
+    let mut args = std::env::args();
+    let binary_name = args
+        .next()
+        .ok_or_else(|| eyre::eyre!("Binary name missing"))?;
+    let filters: Vec<_> = args.collect();
+
+    if filters
+        .iter()
+        .any(|f| f.contains(|c: char| !(c.is_ascii_hexdigit() || c == ':')))
+    {
+        eprintln!("Invalid MAC addresses {:?}", filters);
+        eprintln!("Usage:");
+        eprintln!("  {} [MAC address]...", binary_name);
+        exit(1);
+    }
+
+    Ok(filters)
+}
+
+fn should_include_sensor(sensor: &SensorProps, filters: &Vec<String>) -> bool {
+    let mac = sensor.mac_address.to_string();
+    filters.is_empty() || filters.iter().any(|filter| mac.contains(filter))
+}

--- a/mijia/examples/names.rs
+++ b/mijia/examples/names.rs
@@ -1,22 +1,23 @@
 //! Example of how to subscribe to readings from one or more sensors.
 
 use eyre::Report;
-use mijia::{MijiaEvent, MijiaSession, SensorProps};
-use std::process::exit;
+use mijia::{MijiaSession, SensorProps};
+use std::collections::HashMap;
+use std::io::Write;
 use std::time::Duration;
-use tokio::stream::StreamExt;
+use std::{io::stdin, process::exit};
 use tokio::time;
 
 const SCAN_DURATION: Duration = Duration::from_secs(5);
+const SENSOR_NAMES_FILE: &str = "sensor-names.toml";
 
 #[tokio::main]
 async fn main() -> Result<(), Report> {
     pretty_env_logger::init();
 
-    let filters = parse_args()?;
+    let excludes = get_known_sensors()?;
 
     let (_, session) = MijiaSession::new().await?;
-    let mut events = session.event_stream().await?;
 
     // Start scanning for Bluetooth devices, and wait a while for some to be discovered.
     session.bt_session.start_discovery().await?;
@@ -28,52 +29,59 @@ async fn main() -> Result<(), Report> {
     println!("Sensors:");
     for sensor in sensors
         .iter()
-        .filter(|sensor| should_include_sensor(sensor, &filters))
+        .filter(|sensor| should_include_sensor(sensor, &excludes))
     {
         println!("Connecting to {} ({:?})", sensor.mac_address, sensor.id);
         if let Err(e) = session.bt_session.connect(&sensor.id).await {
             println!("Failed to connect to {}: {:?}", sensor.mac_address, e);
             continue;
         }
-        session.start_notify_sensor(&sensor.id).await?;
-    }
 
-    println!("Readings:");
-    while let Some(event) = events.next().await {
-        match event {
-            MijiaEvent::Readings { id, readings } => {
-                println!("{:?}: {}", id, readings);
-            }
-            _ => println!("Event: {:?}", event),
+        {
+            let sensor = sensor.clone();
+
+            tokio::task::spawn_blocking(move || {
+                use std::fs::OpenOptions;
+                println!(
+                    "What name do you want to use for {} ({:?})?",
+                    sensor.mac_address, sensor.id
+                );
+                let mut name = String::new();
+                stdin().read_line(&mut name)?;
+
+                let mut file = OpenOptions::new().append(true).open(SENSOR_NAMES_FILE)?;
+                writeln!(
+                    file,
+                    r#""{mac}" = "{name}""#,
+                    mac = sensor.mac_address,
+                    name = name
+                )?;
+                Ok::<_, Report>(())
+            })
+            .await??;
         }
+
+        session.bt_session.disconnect(&sensor.id).await?;
     }
 
     Ok(())
 }
 
-fn parse_args() -> Result<Vec<String>, Report> {
-    // If at least one command-line argument is given, we will only try to connect to sensors whose
-    // MAC address containts one of them as a sub-string.
-    let mut args = std::env::args();
-    let binary_name = args
-        .next()
-        .ok_or_else(|| eyre::eyre!("Binary name missing"))?;
-    let filters: Vec<_> = args.collect();
+fn get_known_sensors() -> Result<Vec<String>, Report> {
+    let names = toml::from_str::<HashMap<String, String>>(SENSOR_NAMES_FILE).unwrap_or_default();
 
-    if filters
-        .iter()
+    if names
+        .keys()
         .any(|f| f.contains(|c: char| !(c.is_ascii_hexdigit() || c == ':')))
     {
-        eprintln!("Invalid MAC addresses {:?}", filters);
-        eprintln!("Usage:");
-        eprintln!("  {} [MAC address]...", binary_name);
+        eprintln!("Invalid MAC addresses {:?}", names);
         exit(1);
     }
 
-    Ok(filters)
+    Ok(names.keys().cloned().collect())
 }
 
-fn should_include_sensor(sensor: &SensorProps, filters: &Vec<String>) -> bool {
+fn should_include_sensor(sensor: &SensorProps, excludes: &Vec<String>) -> bool {
     let mac = sensor.mac_address.to_string();
-    filters.is_empty() || filters.iter().any(|filter| mac.contains(filter))
+    !excludes.iter().any(|filter| mac.contains(filter))
 }

--- a/mijia/examples/names.rs
+++ b/mijia/examples/names.rs
@@ -33,9 +33,9 @@ async fn main() -> Result<(), Report> {
         println!("Connecting to {} ({:?})", sensor.mac_address, sensor.id);
         if let Err(e) = session.bt_session.connect(&sensor.id).await {
             println!("Failed to connect to {}: {:?}", sensor.mac_address, e);
-        } else {
-            session.start_notify_sensor(&sensor.id).await?;
+            continue;
         }
+        session.start_notify_sensor(&sensor.id).await?;
     }
 
     println!("Readings:");

--- a/mijia/examples/names.rs
+++ b/mijia/examples/names.rs
@@ -62,7 +62,7 @@ async fn main() -> Result<(), Report> {
                 println!("What name do you want to use for {}?", sensor.mac_address);
                 let mut name = String::new();
                 stdin().read_line(&mut name)?;
-                name.truncate(name.trim_end().len());
+                let name = name.trim_end();
 
                 let mut file = OpenOptions::new()
                     .create(true)

--- a/mijia/examples/names.rs
+++ b/mijia/examples/names.rs
@@ -84,11 +84,9 @@ async fn main() -> Result<(), Report> {
             .await??;
         }
 
-        session
-            .bt_session
-            .disconnect(&sensor.id)
-            .await
-            .or_else(|_| Ok::<(), Report>(println!("disconnecting failed")))?;
+        if let Err(e) = session.bt_session.disconnect(&sensor.id).await {
+            log::error!("disconnecting failed: {:?}", e);
+        }
     }
 
     Ok(())

--- a/mijia/examples/names.rs
+++ b/mijia/examples/names.rs
@@ -35,8 +35,8 @@ async fn main() -> Result<(), Report> {
     session.bt_session.start_discovery().await?;
     time::sleep(SCAN_DURATION).await;
 
-    // Get the list of sensors which are currently known, connect those which match the filter and
-    // subscribe to readings.
+    // Get the list of sensors which are currently known, connect those which
+    // are not already known about.
     let sensors = session.get_sensors().await?;
     for sensor in sensors
         .iter()

--- a/mijia/examples/readings.rs
+++ b/mijia/examples/readings.rs
@@ -33,9 +33,9 @@ async fn main() -> Result<(), Report> {
         println!("Connecting to {} ({})", sensor.mac_address, sensor.id);
         if let Err(e) = session.bt_session.connect(&sensor.id).await {
             println!("Failed to connect to {}: {:?}", sensor.mac_address, e);
-        } else {
-            session.start_notify_sensor(&sensor.id).await?;
+            continue;
         }
+        session.start_notify_sensor(&sensor.id).await?;
     }
 
     println!("Readings:");


### PR DESCRIPTION
Makes the assumption that the config file only contains "name" = "value" entries, and no tables. This matches what we're currently doing in mijia-homie. I think it should bail out early if this assumption doesn't hold, but I haven't tested it.

This is what I used to create `pi@cottagepi.local:mijia-homie/sensor-names.toml` (with a bit of iteration), which includes the addresses of everything in the tower of sensors in the living room, and a bunch of addresses for sensors that I didn't manage to find.

I probably should have made a PR out of this as soon as I made it.

Open questions:
- [x] Is `mijia` the best place for this, or is it more `mijia-homie` specific?
- [ ] I guess I should test it properly by promoting pi@cottagepi.local:mijia-homie/sensor-names.toml to be the one that we're actually using?