### PR TITLE
Add example for RuuviTags

### DIFF
--- a/bluez-async/README.md
+++ b/bluez-async/README.md
@@ -18,7 +18,7 @@ This crate is incomplete, experimental, and may not be supported.
 let (_, session) = BluetoothSession::new().await?;
 
 // Start scanning for Bluetooth devices, and wait a few seconds for some to be discovered.
-session.start_discovery().await?;
+session.start_discovery(&DiscoveryFilter::default()).await?;
 time::sleep(Duration::from_secs(5)).await;
 session.stop_discovery().await?;
 

--- a/bluez-async/examples/characteristics.rs
+++ b/bluez-async/examples/characteristics.rs
@@ -1,3 +1,6 @@
+//! Example to dump information about the services and characteristics of all devices for which we
+//! know them, i.e. connected devices.
+
 use bluez_async::{BleUuid, BluetoothSession, CharacteristicFlags};
 use std::ops::RangeInclusive;
 use std::str;

--- a/bluez-async/examples/devices.rs
+++ b/bluez-async/examples/devices.rs
@@ -1,3 +1,5 @@
+//! Example to scan for a short time and then list all known devices.
+
 use bluez_async::{BluetoothSession, DiscoveryFilter};
 use std::time::Duration;
 use tokio::time;

--- a/bluez-async/examples/devices.rs
+++ b/bluez-async/examples/devices.rs
@@ -1,4 +1,4 @@
-use bluez_async::BluetoothSession;
+use bluez_async::{BluetoothSession, DiscoveryFilter};
 use std::time::Duration;
 use tokio::time;
 
@@ -11,7 +11,7 @@ async fn main() -> Result<(), eyre::Report> {
     let (_, session) = BluetoothSession::new().await?;
 
     // Start scanning for Bluetooth devices, and wait a while for some to be discovered.
-    session.start_discovery().await?;
+    session.start_discovery(&DiscoveryFilter::default()).await?;
     time::sleep(SCAN_DURATION).await;
     session.stop_discovery().await?;
 

--- a/bluez-async/examples/events.rs
+++ b/bluez-async/examples/events.rs
@@ -1,3 +1,5 @@
+//! Example to log Bluetooth events, including duplicate manufacturer-specific advertisement data.
+
 use bluez_async::{BluetoothSession, DiscoveryFilter};
 use futures::stream::StreamExt;
 

--- a/bluez-async/examples/events.rs
+++ b/bluez-async/examples/events.rs
@@ -1,4 +1,4 @@
-use bluez_async::BluetoothSession;
+use bluez_async::{BluetoothSession, DiscoveryFilter};
 use futures::stream::StreamExt;
 
 #[tokio::main]
@@ -7,6 +7,12 @@ async fn main() -> Result<(), eyre::Report> {
 
     let (_, session) = BluetoothSession::new().await?;
     let mut events = session.event_stream().await?;
+    session
+        .start_discovery(&DiscoveryFilter {
+            duplicate_data: Some(true),
+            ..DiscoveryFilter::default()
+        })
+        .await?;
 
     println!("Events:");
     while let Some(event) = events.next().await {

--- a/bluez-async/examples/ruuvitag.rs
+++ b/bluez-async/examples/ruuvitag.rs
@@ -32,7 +32,7 @@ fn temperature(data: &[u8]) -> f64 {
     (value as f64) * 0.005
 }
 
-/// Temperature in `%`.
+/// Humidity in `%`.
 fn humidity(data: &[u8]) -> f64 {
     assert!(data.len() >= 5);
     let value = [data[3], data[4]];
@@ -40,7 +40,7 @@ fn humidity(data: &[u8]) -> f64 {
     (value as f64) * 0.0025
 }
 
-/// Temperature in `%`.
+/// Pressure in `Pa`.
 fn pressure(data: &[u8]) -> f64 {
     assert!(data.len() >= 7);
     let value = [data[5], data[6]];

--- a/bluez-async/examples/ruuvitag.rs
+++ b/bluez-async/examples/ruuvitag.rs
@@ -1,0 +1,80 @@
+//! Example to log sensor measurements of [RuuviTag]s.
+//!
+//! RuuviTags broadcast their sensor's measurements via the manufacturer
+//! specific data advertisements. Accordingly, duplicate data must be excepted.
+//!
+//! In detail this example looks for RuuviTags in reach and writes temperature,
+//! humidity and air pressure to `stdout` for each measurement.
+//!
+//!
+//! [RuuviTag]: https://ruuvi.com/ruuvitag-specs/
+
+use bluez_async::{BluetoothSession, DiscoveryFilter, BluetoothEvent, DeviceEvent};
+use futures::stream::StreamExt;
+
+/// The [Bluetooth company identifier](https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers/) of Ruuvi Innovations Ltd.
+const RUUVI_ID: u16 = 0x0499;
+
+/// Protocol version of RuuviTags' data format [RAWv2](https://github.com/ruuvi/ruuvi-sensor-protocols/blob/master/dataformat_05.md)
+const PROTOCOL_VERSION: u8 = 0x05;
+
+/// Search for manufacturer data from a Ruuvi device with protocol version 5.
+fn get_ruuvi_data(mdata: impl Iterator<Item = (u16, Vec<u8>)>) -> Option<Vec<u8>> {
+    let mut mdata = mdata;
+    mdata.find(|(id, data)| *id == RUUVI_ID && !data.is_empty() && data[0] == PROTOCOL_VERSION).map(|(_, data)| data)
+}
+
+/// Temperature in `°C`.
+fn temperature(data: &[u8]) -> f64 {
+    assert!(data.len() >= 3);
+    let value = [data[1], data[2]];
+    let value = u16::from_be_bytes(value);
+    (value as f64) * 0.005
+}
+
+/// Temperature in `%`.
+fn humidity(data: &[u8]) -> f64 {
+    assert!(data.len() >= 5);
+    let value = [data[3], data[4]];
+    let value = u16::from_be_bytes(value);
+    (value as f64) * 0.0025
+}
+
+/// Temperature in `%`.
+fn pressure(data: &[u8]) -> f64 {
+    assert!(data.len() >= 7);
+    let value = [data[5], data[6]];
+    let value = u16::from_be_bytes(value);
+    (value as f64) + 50_000_f64
+}
+
+#[tokio::main]
+async fn main() -> Result<(), eyre::Report> {
+    pretty_env_logger::init();
+
+    let (_, session) = BluetoothSession::new().await?;
+    let mut events = session.event_stream().await?;
+    session
+        .start_discovery(&DiscoveryFilter {
+            duplicate_data: Some(true),
+            ..DiscoveryFilter::default()
+        })
+        .await?;
+
+    println!("Events:");
+    while let Some(event) = events.next().await {
+        match event {
+            BluetoothEvent::Device { id, event: DeviceEvent::ManufacturerData {manufacturer_data} } => {
+                if let Some(data) = get_ruuvi_data(manufacturer_data.into_iter()) {
+                    let t = temperature(&data);
+                    let h = humidity(&data);
+                    let p = pressure(&data);
+                    println!("RuuviTag {} measured: t = {:6.2} °C, h = {:6.2} %, p = {:6} Pa", id, t, h, p);
+                }
+            },
+            _ => {},
+        }
+    }
+
+    Ok(())
+}

--- a/bluez-async/src/lib.rs
+++ b/bluez-async/src/lib.rs
@@ -555,7 +555,7 @@ impl Into<PropMap> for &DiscoveryFilter {
 /// from different places. It is the main entry point to the library.
 #[derive(Clone)]
 pub struct BluetoothSession {
-    pub connection: Arc<SyncConnection>,
+    connection: Arc<SyncConnection>,
 }
 
 impl Debug for BluetoothSession {

--- a/bluez-async/src/lib.rs
+++ b/bluez-async/src/lib.rs
@@ -21,7 +21,7 @@ use bluez_generated::{
     OrgBluezAdapter1, OrgBluezDevice1, OrgBluezDevice1Properties, OrgBluezGattCharacteristic1,
     OrgBluezGattDescriptor1, OrgBluezGattService1, ORG_BLUEZ_ADAPTER1_NAME, ORG_BLUEZ_DEVICE1_NAME,
 };
-use dbus::arg::{cast, RefArg, Variant};
+use dbus::arg::{cast, PropMap, RefArg, Variant};
 use dbus::nonblock::stdintf::org_freedesktop_dbus::{Introspectable, ObjectManager, Properties};
 use dbus::nonblock::{Proxy, SyncConnection};
 use dbus::Path;
@@ -462,6 +462,95 @@ pub struct DescriptorInfo {
     pub uuid: Uuid,
 }
 
+/// The type of transport to use for a scan.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Transport {
+    /// Interleaved scan, both BLE and Bluetooth Classic (if they are both enabled on the adapter).
+    Auto,
+    /// BR/EDR inquiry, i.e. Bluetooth Classic.
+    BrEdr,
+    /// LE scan only.
+    Le,
+}
+
+impl Transport {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::BrEdr => "bredr",
+            Self::Le => "le",
+        }
+    }
+}
+
+impl Display for Transport {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A set of filter parameters for discovery. Parameters may be set to `None` to use the BlueZ
+/// defaults.
+///
+/// If no parameters are set then there is a default filter on the RSSI values, where only values
+/// which have changed more than a certain amount will be reported.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct DiscoveryFilter {
+    /// If non-empty, only report devices which advertise at least one of these service UUIDs.
+    pub service_uuids: Vec<Uuid>,
+    /// Only report devices with RSSI values greater than the given threshold.
+    pub rssi_threshold: Option<i16>,
+    pub pathloss_threshold: Option<u16>,
+    /// The type of scan.
+    pub transport: Option<Transport>,
+    /// Whether to include duplicate advertisements. If this is set to true then there will be an
+    /// event whenever an advertisement containing manufacturer-specific data for a device is
+    /// received.
+    pub duplicate_data: Option<bool>,
+    /// Whether to make the adapter discoverable while discovering.
+    pub discoverable: Option<bool>,
+    /// Only report devices whose address or name starts with the given pattern.
+    pub pattern: Option<String>,
+}
+
+impl Into<PropMap> for &DiscoveryFilter {
+    fn into(self) -> PropMap {
+        let mut map: PropMap = HashMap::new();
+        if !self.service_uuids.is_empty() {
+            let uuids: Vec<String> = self.service_uuids.iter().map(Uuid::to_string).collect();
+            map.insert("UUIDs".to_string(), Variant(Box::new(uuids)));
+        }
+        if let Some(rssi_threshold) = self.rssi_threshold {
+            map.insert("RSSI".to_string(), Variant(Box::new(rssi_threshold)));
+        }
+        if let Some(pathloss_threshold) = self.pathloss_threshold {
+            map.insert(
+                "Pathloss".to_string(),
+                Variant(Box::new(pathloss_threshold)),
+            );
+        }
+        if let Some(transport) = self.transport {
+            map.insert(
+                "Transport".to_string(),
+                Variant(Box::new(transport.to_string())),
+            );
+        }
+        if let Some(duplicate_data) = self.duplicate_data {
+            map.insert(
+                "DuplicateData".to_string(),
+                Variant(Box::new(duplicate_data)),
+            );
+        }
+        if let Some(discoverable) = self.discoverable {
+            map.insert("Discoverable".to_string(), Variant(Box::new(discoverable)));
+        }
+        if let Some(pattern) = &self.pattern {
+            map.insert("Pattern".to_string(), Variant(Box::new(pattern.to_owned())));
+        }
+        map
+    }
+}
+
 /// A connection to the Bluetooth daemon. This can be cheaply cloned and passed around to be used
 /// from different places. It is the main entry point to the library.
 #[derive(Clone)]
@@ -497,8 +586,18 @@ impl BluetoothSession {
         ))
     }
 
-    /// Power on all Bluetooth adapters and start scanning for devices.
-    pub async fn start_discovery(&self) -> Result<(), BluetoothError> {
+    /// Power on all Bluetooth adapters, set the given discovery filter, and then start scanning for
+    /// devices.
+    ///
+    /// Note that BlueZ combines discovery filters from all clients and sends events matching any
+    /// filter to all clients, so you may receive unexpected discovery events if there are other
+    /// clients on the system using Bluetooth as well.
+    ///
+    /// In most common cases, `DiscoveryFilter::default()` is fine.
+    pub async fn start_discovery(
+        &self,
+        discovery_filter: &DiscoveryFilter,
+    ) -> Result<(), BluetoothError> {
         let adapters = self.get_adapters().await?;
         if adapters.is_empty() {
             return Err(BluetoothError::NoBluetoothAdapters);
@@ -508,6 +607,9 @@ impl BluetoothSession {
             log::trace!("Starting discovery on adapter {}", adapter_id);
             let adapter = self.adapter(&adapter_id);
             adapter.set_powered(true).await?;
+            adapter
+                .set_discovery_filter(discovery_filter.into())
+                .await?;
             adapter
                 .start_discovery()
                 .await

--- a/mijia-homie/src/main.rs
+++ b/mijia-homie/src/main.rs
@@ -317,7 +317,10 @@ async fn check_for_sensors(
     session: &MijiaSession,
     sensor_names: &HashMap<MacAddress, String>,
 ) -> Result<(), eyre::Report> {
-    session.bt_session.start_discovery().await?;
+    session
+        .bt_session
+        .start_discovery(&Default::default())
+        .await?;
 
     let sensors = session.get_sensors().await?;
     let state = &mut *state.lock().await;

--- a/mijia/README.md
+++ b/mijia/README.md
@@ -15,7 +15,7 @@ Currently only supports running on Linux, as it depends on BlueZ for Bluetooth.
 let (_, session) = MijiaSession::new().await?;
 
 // Start scanning for Bluetooth devices, and wait a few seconds for some to be discovered.
-session.bt_session.start_discovery().await?;
+session.bt_session.start_discovery(&Default::default()).await?;
 time::sleep(Duration::from_secs(5)).await;
 
 // Get the list of sensors which are currently known.

--- a/mijia/examples/list-sensors.rs
+++ b/mijia/examples/list-sensors.rs
@@ -11,7 +11,10 @@ async fn main() -> Result<(), eyre::Report> {
     let (_, session) = MijiaSession::new().await?;
 
     // Start scanning for Bluetooth devices, and wait a while for some to be discovered.
-    session.bt_session.start_discovery().await?;
+    session
+        .bt_session
+        .start_discovery(&Default::default())
+        .await?;
     time::sleep(SCAN_DURATION).await;
 
     // Get the list of sensors which are currently known and print them.

--- a/mijia/examples/properties.rs
+++ b/mijia/examples/properties.rs
@@ -16,7 +16,10 @@ async fn main() -> Result<(), Report> {
     let (_, session) = MijiaSession::new().await?;
 
     // Start scanning for Bluetooth devices, and wait a while for some to be discovered.
-    session.bt_session.start_discovery().await?;
+    session
+        .bt_session
+        .start_discovery(&Default::default())
+        .await?;
     time::sleep(SCAN_DURATION).await;
 
     // Get the list of sensors which are currently known, connect to them and print their properties.

--- a/mijia/examples/readings.rs
+++ b/mijia/examples/readings.rs
@@ -19,7 +19,10 @@ async fn main() -> Result<(), Report> {
     let mut events = session.event_stream().await?;
 
     // Start scanning for Bluetooth devices, and wait a while for some to be discovered.
-    session.bt_session.start_discovery().await?;
+    session
+        .bt_session
+        .start_discovery(&Default::default())
+        .await?;
     time::sleep(SCAN_DURATION).await;
 
     // Get the list of sensors which are currently known, connect those which match the filter and

--- a/mijia/src/lib.rs
+++ b/mijia/src/lib.rs
@@ -158,7 +158,7 @@ impl MijiaEvent {
 /// let (_, session) = MijiaSession::new().await?;
 ///
 /// // Start scanning for Bluetooth devices, and wait a few seconds for some to be discovered.
-/// session.bt_session.start_discovery().await?;
+/// session.bt_session.start_discovery(&Default::default()).await?;
 /// time::sleep(Duration::from_secs(5)).await;
 ///
 /// // Get the list of sensors which are currently known.


### PR DESCRIPTION
As announced in #129 this is an example to proof that the new feature for manufacturer specific data works with a RuuviTag.

With my laptop `hciconfig -a`:

```
hci0:	Type: Primary  Bus: USB
	BD Address: xx:xx:xx:xx:xx:xx  ACL MTU: 1021:4  SCO MTU: 96:6
	UP RUNNING PSCAN 
	RX bytes:146397 acl:0 sco:0 events:6944 errors:0
	TX bytes:692973 acl:0 sco:0 commands:4361 errors:0
	Features: 0xbf 0xfe 0x0f 0xfe 0xdb 0xff 0x7b 0x87
	Packet type: DM1 DM3 DM5 DH1 DH3 DH5 HV1 HV2 HV3 
	Link policy: RSWITCH SNIFF 
	Link mode: SLAVE ACCEPT 
	Name: 'xyz'
	Class: 0x0c010c
	Service Classes: Rendering, Capturing
	Device Class: Computer, Laptop
	HCI Version: 5.1 (0xa)  Revision: 0x100
	LMP Version: 5.1 (0xa)  Subversion: 0x100
	Manufacturer: Intel Corp. (2)
```

and a RuuviTag the example works as expected.