### PR TITLE
Add methods to get information about Bluetooth adapters

### DIFF
--- a/bluez-async/CHANGELOG.md
+++ b/bluez-async/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Breaking changes
+
+- `BluetoothSession::get_adapters()` now returns `AdapterInfo`s rather than `AdapterId`s.
+
+### New features
+
+- Added `AdapterInfo` struct with information about the status of a Bluetooth adapter, and methods
+  to get it for all adapters on the system or a specific adapter.
+
 ## 0.2.1
 
 ### New features

--- a/bluez-async/examples/adapters.rs
+++ b/bluez-async/examples/adapters.rs
@@ -1,0 +1,16 @@
+//! Example to show information about the Bluetooth adapters on the system.
+
+use bluez_async::BluetoothSession;
+
+#[tokio::main]
+async fn main() -> Result<(), eyre::Report> {
+    pretty_env_logger::init();
+
+    let (_, session) = BluetoothSession::new().await?;
+
+    // Get the list of all Bluetooh adapters on the system.
+    let adapters = session.get_adapters().await?;
+    println!("Adapters: {:#?}", adapters);
+
+    Ok(())
+}

--- a/bluez-async/src/adapter.rs
+++ b/bluez-async/src/adapter.rs
@@ -57,10 +57,10 @@ impl AdapterInfo {
     ) -> Result<AdapterInfo, BluetoothError> {
         let mac_address = adapter_properties
             .address()
-            .ok_or_else(|| BluetoothError::RequiredPropertyMissing("Address".to_string()))?;
+            .ok_or_else(|| BluetoothError::RequiredPropertyMissing("Address"))?;
         let address_type = adapter_properties
             .address_type()
-            .ok_or_else(|| BluetoothError::RequiredPropertyMissing("AddressType".to_string()))?
+            .ok_or_else(|| BluetoothError::RequiredPropertyMissing("AddressType"))?
             .parse()?;
 
         Ok(AdapterInfo {
@@ -69,18 +69,18 @@ impl AdapterInfo {
             address_type,
             name: adapter_properties
                 .name()
-                .ok_or_else(|| BluetoothError::RequiredPropertyMissing("Name".to_string()))?
+                .ok_or_else(|| BluetoothError::RequiredPropertyMissing("Name"))?
                 .to_owned(),
             alias: adapter_properties
                 .alias()
-                .ok_or_else(|| BluetoothError::RequiredPropertyMissing("Alias".to_string()))?
+                .ok_or_else(|| BluetoothError::RequiredPropertyMissing("Alias"))?
                 .to_owned(),
             powered: adapter_properties
                 .powered()
-                .ok_or_else(|| BluetoothError::RequiredPropertyMissing("Powered".to_string()))?,
-            discovering: adapter_properties.discovering().ok_or_else(|| {
-                BluetoothError::RequiredPropertyMissing("Discovering".to_string())
-            })?,
+                .ok_or_else(|| BluetoothError::RequiredPropertyMissing("Powered"))?,
+            discovering: adapter_properties
+                .discovering()
+                .ok_or_else(|| BluetoothError::RequiredPropertyMissing("Discovering"))?,
         })
     }
 }

--- a/bluez-async/src/adapter.rs
+++ b/bluez-async/src/adapter.rs
@@ -1,5 +1,8 @@
+use bluez_generated::OrgBluezAdapter1Properties;
 use dbus::Path;
 use std::fmt::{self, Display, Formatter};
+
+use crate::{AddressType, BluetoothError, MacAddress};
 
 /// Opaque identifier for a Bluetooth adapter on the system.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -24,6 +27,88 @@ impl Display for AdapterId {
                 .to_string()
                 .strip_prefix("/org/bluez/")
                 .ok_or(fmt::Error)?
+        )
+    }
+}
+
+/// Information about a Bluetooth adapter on the system.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdapterInfo {
+    /// An opaque identifier for the adapter. This can be used to perform operations on it.
+    pub id: AdapterId,
+    /// The MAC address of the adapter.
+    pub mac_address: MacAddress,
+    /// The type of MAC address the adapter uses.
+    pub address_type: AddressType,
+    /// Whether the adapter is currently turned on.
+    pub powered: bool,
+    /// Whether the adapter is currently discovering devices.
+    pub discovering: bool,
+}
+
+impl AdapterInfo {
+    pub(crate) fn from_properties(
+        id: AdapterId,
+        adapter_properties: OrgBluezAdapter1Properties,
+    ) -> Result<AdapterInfo, BluetoothError> {
+        let mac_address = adapter_properties
+            .address()
+            .ok_or_else(|| BluetoothError::RequiredPropertyMissing("Address".to_string()))?;
+        let address_type = adapter_properties
+            .address_type()
+            .ok_or_else(|| BluetoothError::RequiredPropertyMissing("AddressType".to_string()))?
+            .parse()?;
+
+        Ok(AdapterInfo {
+            id,
+            mac_address: MacAddress(mac_address.to_owned()),
+            address_type,
+            powered: adapter_properties
+                .powered()
+                .ok_or_else(|| BluetoothError::RequiredPropertyMissing("Powered".to_string()))?,
+            discovering: adapter_properties.discovering().ok_or_else(|| {
+                BluetoothError::RequiredPropertyMissing("Discovering".to_string())
+            })?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dbus::arg::{RefArg, Variant};
+    use std::collections::HashMap;
+
+    use super::*;
+
+    #[test]
+    fn adapter_info_minimal() {
+        let id = AdapterId::new("/org/bluez/hci0");
+        let mut adapter_properties: HashMap<String, Variant<Box<dyn RefArg>>> = HashMap::new();
+        adapter_properties.insert(
+            "Address".to_string(),
+            Variant(Box::new("00:11:22:33:44:55".to_string())),
+        );
+        adapter_properties.insert(
+            "AddressType".to_string(),
+            Variant(Box::new("public".to_string())),
+        );
+        adapter_properties.insert("Powered".to_string(), Variant(Box::new(false)));
+        adapter_properties.insert("Discovering".to_string(), Variant(Box::new(false)));
+
+        let adapter = AdapterInfo::from_properties(
+            id.clone(),
+            OrgBluezAdapter1Properties(&adapter_properties),
+        )
+        .unwrap();
+        assert_eq!(
+            adapter,
+            AdapterInfo {
+                id,
+                mac_address: MacAddress("00:11:22:33:44:55".to_string()),
+                address_type: AddressType::Public,
+                powered: false,
+                discovering: false
+            }
         )
     }
 }

--- a/bluez-async/src/adapter.rs
+++ b/bluez-async/src/adapter.rs
@@ -40,6 +40,10 @@ pub struct AdapterInfo {
     pub mac_address: MacAddress,
     /// The type of MAC address the adapter uses.
     pub address_type: AddressType,
+    /// The Bluetooth system hostname.
+    pub name: String,
+    /// The Bluetooth friendly name. This defaults to the system hostname.
+    pub alias: String,
     /// Whether the adapter is currently turned on.
     pub powered: bool,
     /// Whether the adapter is currently discovering devices.
@@ -63,6 +67,14 @@ impl AdapterInfo {
             id,
             mac_address: MacAddress(mac_address.to_owned()),
             address_type,
+            name: adapter_properties
+                .name()
+                .ok_or_else(|| BluetoothError::RequiredPropertyMissing("Name".to_string()))?
+                .to_owned(),
+            alias: adapter_properties
+                .alias()
+                .ok_or_else(|| BluetoothError::RequiredPropertyMissing("Alias".to_string()))?
+                .to_owned(),
             powered: adapter_properties
                 .powered()
                 .ok_or_else(|| BluetoothError::RequiredPropertyMissing("Powered".to_string()))?,
@@ -92,6 +104,8 @@ mod tests {
             "AddressType".to_string(),
             Variant(Box::new("public".to_string())),
         );
+        adapter_properties.insert("Name".to_string(), Variant(Box::new("name".to_string())));
+        adapter_properties.insert("Alias".to_string(), Variant(Box::new("alias".to_string())));
         adapter_properties.insert("Powered".to_string(), Variant(Box::new(false)));
         adapter_properties.insert("Discovering".to_string(), Variant(Box::new(false)));
 
@@ -106,6 +120,8 @@ mod tests {
                 id,
                 mac_address: MacAddress("00:11:22:33:44:55".to_string()),
                 address_type: AddressType::Public,
+                name: "name".to_string(),
+                alias: "alias".to_string(),
                 powered: false,
                 discovering: false
             }

--- a/bluez-async/src/device.rs
+++ b/bluez-async/src/device.rs
@@ -95,10 +95,10 @@ impl DeviceInfo {
     ) -> Result<DeviceInfo, BluetoothError> {
         let mac_address = device_properties
             .address()
-            .ok_or_else(|| BluetoothError::RequiredPropertyMissing("Address".to_string()))?;
+            .ok_or_else(|| BluetoothError::RequiredPropertyMissing("Address"))?;
         let address_type = device_properties
             .address_type()
-            .ok_or_else(|| BluetoothError::RequiredPropertyMissing("AddressType".to_string()))?
+            .ok_or_else(|| BluetoothError::RequiredPropertyMissing("AddressType"))?
             .parse()?;
         let services = get_services(device_properties);
         let manufacturer_data = get_manufacturer_data(device_properties).unwrap_or_default();
@@ -113,17 +113,17 @@ impl DeviceInfo {
             services,
             paired: device_properties
                 .paired()
-                .ok_or_else(|| BluetoothError::RequiredPropertyMissing("Paired".to_string()))?,
+                .ok_or_else(|| BluetoothError::RequiredPropertyMissing("Paired"))?,
             connected: device_properties
                 .connected()
-                .ok_or_else(|| BluetoothError::RequiredPropertyMissing("Connected".to_string()))?,
+                .ok_or_else(|| BluetoothError::RequiredPropertyMissing("Connected"))?,
             rssi: device_properties.rssi(),
             tx_power: device_properties.tx_power(),
             manufacturer_data,
             service_data,
-            services_resolved: device_properties.services_resolved().ok_or_else(|| {
-                BluetoothError::RequiredPropertyMissing("ServicesResolved".to_string())
-            })?,
+            services_resolved: device_properties
+                .services_resolved()
+                .ok_or_else(|| BluetoothError::RequiredPropertyMissing("ServicesResolved"))?,
         })
     }
 }

--- a/bluez-async/src/lib.rs
+++ b/bluez-async/src/lib.rs
@@ -79,7 +79,7 @@ pub enum BluetoothError {
     AddressTypeParseError(String),
     /// A required property of some device or other object was not found.
     #[error("Required property {0} missing.")]
-    RequiredPropertyMissing(String),
+    RequiredPropertyMissing(&'static str),
     /// Service discovery didn't happen within the time limit.
     #[error("Service discovery timed out")]
     ServiceDiscoveryTimedOut,

--- a/bluez-async/src/lib.rs
+++ b/bluez-async/src/lib.rs
@@ -17,7 +17,7 @@ mod introspect;
 mod messagestream;
 mod service;
 
-pub use self::adapter::AdapterId;
+pub use self::adapter::{AdapterId, AdapterInfo};
 pub use self::bleuuid::{uuid_from_u16, uuid_from_u32, BleUuid};
 pub use self::characteristic::{CharacteristicFlags, CharacteristicId, CharacteristicInfo};
 pub use self::descriptor::{DescriptorId, DescriptorInfo};
@@ -27,8 +27,9 @@ use self::introspect::IntrospectParse;
 use self::messagestream::MessageStream;
 pub use self::service::{ServiceId, ServiceInfo};
 use bluez_generated::{
-    OrgBluezAdapter1, OrgBluezDevice1, OrgBluezDevice1Properties, OrgBluezGattCharacteristic1,
-    OrgBluezGattDescriptor1, OrgBluezGattService1, ORG_BLUEZ_ADAPTER1_NAME, ORG_BLUEZ_DEVICE1_NAME,
+    OrgBluezAdapter1, OrgBluezAdapter1Properties, OrgBluezDevice1, OrgBluezDevice1Properties,
+    OrgBluezGattCharacteristic1, OrgBluezGattDescriptor1, OrgBluezGattService1,
+    ORG_BLUEZ_ADAPTER1_NAME, ORG_BLUEZ_DEVICE1_NAME,
 };
 use dbus::arg::{PropMap, Variant};
 use dbus::nonblock::stdintf::org_freedesktop_dbus::{Introspectable, ObjectManager, Properties};
@@ -353,9 +354,9 @@ impl BluetoothSession {
             return Err(BluetoothError::NoBluetoothAdapters);
         }
 
-        for adapter_id in adapters {
-            log::trace!("Starting discovery on adapter {}", adapter_id);
-            self.start_discovery_on_adapter_with_filter(&adapter_id, discovery_filter)
+        for adapter in adapters {
+            log::trace!("Starting discovery on adapter {}", adapter.id);
+            self.start_discovery_on_adapter_with_filter(&adapter.id, discovery_filter)
                 .await
                 .unwrap_or_else(|err| println!("starting discovery failed {:?}", err));
         }
@@ -391,8 +392,8 @@ impl BluetoothSession {
             return Err(BluetoothError::NoBluetoothAdapters);
         }
 
-        for adapter_id in adapters {
-            self.stop_discovery_on_adapter(&adapter_id).await?;
+        for adapter in adapters {
+            self.stop_discovery_on_adapter(&adapter.id).await?;
         }
 
         Ok(())
@@ -409,7 +410,7 @@ impl BluetoothSession {
     }
 
     /// Get a list of all Bluetooth adapters on the system.
-    pub async fn get_adapters(&self) -> Result<Vec<AdapterId>, BluetoothError> {
+    pub async fn get_adapters(&self) -> Result<Vec<AdapterInfo>, BluetoothError> {
         let bluez_root = Proxy::new(
             "org.bluez",
             "/",
@@ -422,9 +423,8 @@ impl BluetoothSession {
         Ok(tree
             .into_iter()
             .filter_map(|(object_path, interfaces)| {
-                interfaces
-                    .get(ORG_BLUEZ_ADAPTER1_NAME)
-                    .map(|_| AdapterId { object_path })
+                let adapter_properties = OrgBluezAdapter1Properties::from_interfaces(&interfaces)?;
+                AdapterInfo::from_properties(AdapterId { object_path }, adapter_properties).ok()
             })
             .collect())
     }
@@ -596,6 +596,13 @@ impl BluetoothSession {
         let device = self.device(&id);
         let properties = device.get_all(ORG_BLUEZ_DEVICE1_NAME).await?;
         DeviceInfo::from_properties(id.to_owned(), OrgBluezDevice1Properties(&properties))
+    }
+
+    /// Get information about the given Bluetooth adapter.
+    pub async fn get_adapter_info(&self, id: &AdapterId) -> Result<AdapterInfo, BluetoothError> {
+        let adapter = self.adapter(&id);
+        let properties = adapter.get_all(ORG_BLUEZ_ADAPTER1_NAME).await?;
+        AdapterInfo::from_properties(id.to_owned(), OrgBluezAdapter1Properties(&properties))
     }
 
     /// Get information about the given GATT service.


### PR DESCRIPTION
This adds `AdapterInfo` with the name, alias, MAC address and status.