### PR TITLE
Update to latest version of influx_db_client.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,7 +820,27 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio 0.2.24",
- "tokio-util",
+ "tokio-util 0.3.1",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
+dependencies = [
+ "bytes 1.0.0",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio 1.0.1",
+ "tokio-util 0.6.3",
  "tracing",
  "tracing-futures",
 ]
@@ -924,7 +944,6 @@ dependencies = [
  "serde_derive",
  "stable-eyre",
  "tokio 1.0.1",
- "tokio-compat-02 0.2.0",
  "toml",
  "url",
 ]
@@ -947,6 +966,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
  "bytes 0.5.6",
+ "http",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
+dependencies = [
+ "bytes 1.0.0",
  "http",
 ]
 
@@ -981,9 +1010,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.2.7",
  "http",
- "http-body",
+ "http-body 0.3.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -996,16 +1025,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.4.3"
+name = "hyper"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
+checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
 dependencies = [
- "bytes 0.5.6",
- "hyper",
+ "bytes 1.0.0",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.0",
+ "http",
+ "http-body 0.4.0",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project 1.0.2",
+ "socket2",
+ "tokio 1.0.1",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes 1.0.0",
+ "hyper 0.14.4",
  "native-tls",
- "tokio 0.2.24",
- "tokio-tls",
+ "tokio 1.0.1",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -1054,11 +1107,11 @@ dependencies = [
 
 [[package]]
 name = "influx_db_client"
-version = "0.4.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8fd2e7258524ce458dcf1b6a722999667687e17955efdf038b7bffded9579f"
+checksum = "49f1a5abf7f7759f14075abcc0140d79a339729e50042ddf93fc0de9d11ddb1f"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.0",
  "futures",
  "reqwest",
  "serde",
@@ -2086,33 +2139,32 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.10.10"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
+checksum = "fd281b1030aa675fb90aa994d07187645bb3c8fc756ca766e7c3070b439de9de"
 dependencies = [
  "base64 0.13.0",
- "bytes 0.5.6",
+ "bytes 1.0.0",
  "encoding_rs",
  "futures-core",
  "futures-util",
  "http",
- "http-body",
- "hyper",
+ "http-body 0.4.0",
+ "hyper 0.14.4",
  "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
- "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite 0.2.0",
  "serde",
  "serde_json",
  "serde_urlencoded 0.7.0",
- "tokio 0.2.24",
- "tokio-tls",
+ "tokio 1.0.1",
+ "tokio-native-tls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -2184,7 +2236,7 @@ dependencies = [
  "serde",
  "thiserror",
  "tokio 1.0.1",
- "tokio-compat-02 0.1.2",
+ "tokio-compat-02",
  "tokio-rustls",
  "warp",
 ]
@@ -2684,20 +2736,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-compat-02"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d4237822b7be8fff0a7a27927462fad435dcb6650f95cea9e946bf6bdc7e07"
-dependencies = [
- "bytes 0.5.6",
- "once_cell",
- "pin-project-lite 0.2.0",
- "tokio 0.2.24",
- "tokio 1.0.1",
- "tokio-stream",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2706,6 +2744,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio 1.0.1",
 ]
 
 [[package]]
@@ -2728,16 +2776,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite 0.2.0",
  "tokio 1.0.1",
-]
-
-[[package]]
-name = "tokio-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
-dependencies = [
- "native-tls",
- "tokio 0.2.24",
 ]
 
 [[package]]
@@ -2765,6 +2803,20 @@ dependencies = [
  "log",
  "pin-project-lite 0.1.11",
  "tokio 0.2.24",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
+dependencies = [
+ "bytes 1.0.0",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite 0.2.0",
+ "tokio 1.0.1",
 ]
 
 [[package]]
@@ -2973,7 +3025,7 @@ dependencies = [
  "futures",
  "headers",
  "http",
- "hyper",
+ "hyper 0.13.9",
  "log",
  "mime",
  "mime_guess",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
  "tokio 1.0.1",
  "tokio-rustls",
  "tungstenite",
- "webpki-roots",
+ "webpki-roots 0.20.0",
 ]
 
 [[package]]
@@ -605,21 +605,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,16 +1034,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
+name = "hyper-rustls"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
 dependencies = [
- "bytes 1.0.0",
+ "futures-util",
  "hyper 0.14.4",
- "native-tls",
+ "log",
+ "rustls",
  "tokio 1.0.1",
- "tokio-native-tls",
+ "tokio-rustls",
+ "webpki",
 ]
 
 [[package]]
@@ -1458,24 +1445,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "net2"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1602,37 +1571,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "openssl"
-version = "0.10.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70"
-dependencies = [
- "bitflags",
- "cfg-if 1.0.0",
- "foreign-types",
- "lazy_static",
- "libc",
- "openssl-sys",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
-dependencies = [
- "autocfg 1.0.1",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "parking_lot"
@@ -2151,24 +2093,25 @@ dependencies = [
  "http",
  "http-body 0.4.0",
  "hyper 0.14.4",
- "hyper-tls",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite 0.2.0",
+ "rustls",
  "serde",
  "serde_json",
  "serde_urlencoded 0.7.0",
  "tokio 1.0.1",
- "tokio-native-tls",
+ "tokio-rustls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 0.21.0",
  "winreg",
 ]
 
@@ -2747,16 +2690,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
-dependencies = [
- "native-tls",
- "tokio 1.0.1",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2988,12 +2921,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
-
-[[package]]
 name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3148,6 +3075,15 @@ name = "webpki-roots"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f20dea7535251981a9670857150d571846545088359b28e4951d350bdaf179f"
+dependencies = [
+ "webpki",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82015b7e0b8bad8185994674a13a93306bea76cf5a16c5a181382fd3a5ec2376"
 dependencies = [
  "webpki",
 ]

--- a/Cross.toml
+++ b/Cross.toml
@@ -2,7 +2,7 @@
 # Based on https://www.collabora.com/news-and-blog/blog/2020/06/23/cross-building-rust-gstreamer-plugins-for-the-raspberry-pi/
 # but with `RUN apt-get install -y libdbus-1-dev:armhf` thrown in to get the dependency we need.
 # This image has been pushed to dockerhub.
-image = "ghcr.io/qwandor/cross-dbus-debian-buster-armv7:0.2.1"
+image = "ghcr.io/qwandor/cross-dbus-debian-buster-armv7:0.2.1-1"
 
 # Once https://github.com/rust-embedded/cross/pull/446 gets somewhere, you
 # will be able to use `context` and `dockerfile` to achieve the same result.
@@ -13,13 +13,13 @@ image = "ghcr.io/qwandor/cross-dbus-debian-buster-armv7:0.2.1"
 # dockerfile = "./docker/Dockerfile.debian-buster-armv7"
 
 [target.aarch64-unknown-linux-gnu]
-image = "ghcr.io/qwandor/cross-dbus-debian-buster-aarch64:0.2.1"
+image = "ghcr.io/qwandor/cross-dbus-debian-buster-aarch64:0.2.1-1"
 
 # context = "./docker"
 # dockerfile = "./docker/Dockerfile.debian-buster-aarch64"
 
 [target.x86_64-unknown-linux-gnu]
-image = "ghcr.io/qwandor/cross-dbus-debian-buster-x86_64:0.2.1"
+image = "ghcr.io/qwandor/cross-dbus-debian-buster-x86_64:0.2.1-1"
 
 # context = "./docker"
 # dockerfile = "./docker/Dockerfile.debian-buster-x86_64"

--- a/docker/Dockerfile.debian-buster-aarch64
+++ b/docker/Dockerfile.debian-buster-aarch64
@@ -18,7 +18,7 @@ RUN apt-get install --assume-yes --no-install-recommends \
 
 RUN dpkg --add-architecture arm64 && \
 	apt-get update && \
-	apt-get install -y libssl-dev:arm64 libdbus-1-dev:arm64
+	apt-get install -y libdbus-1-dev:arm64
 
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
 	CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \

--- a/docker/Dockerfile.debian-buster-armv7
+++ b/docker/Dockerfile.debian-buster-armv7
@@ -18,7 +18,7 @@ RUN apt-get install --assume-yes --no-install-recommends \
 
 RUN dpkg --add-architecture armhf && \
 	apt-get update && \
-	apt-get install -y libssl-dev:armhf libdbus-1-dev:armhf
+	apt-get install -y libdbus-1-dev:armhf
 
 ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
 	CC_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-gcc \

--- a/docker/Dockerfile.debian-buster-x86_64
+++ b/docker/Dockerfile.debian-buster-x86_64
@@ -13,4 +13,4 @@ COPY --from=context xargo.sh /
 RUN /xargo.sh
 
 RUN apt-get update && \
-	apt-get install -y libssl-dev libdbus-1-dev
+	apt-get install -y libdbus-1-dev

--- a/docker/update.sh
+++ b/docker/update.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-VERSION=0.2.1
+VERSION=0.2.1-1
 
 docker build ./docker -f docker/Dockerfile.debian-buster-aarch64 \
     -t ghcr.io/qwandor/cross-dbus-debian-buster-aarch64:$VERSION

--- a/homie-influx/Cargo.toml
+++ b/homie-influx/Cargo.toml
@@ -14,7 +14,7 @@ color-backtrace = "0.5.0"
 eyre = "0.6.5"
 futures = "0.3.8"
 homie-controller = { version = "0.3.0", path = "../homie-controller" }
-influx_db_client = "0.5.0"
+influx_db_client = { version = "0.5.0", default-features = false, features = ["rustls-tls"] }
 log = "0.4.11"
 pretty_env_logger = "0.4.0"
 rumqttc = "0.4.0"
@@ -29,7 +29,7 @@ url = { version = "2.2.0", features = ["serde"] }
 
 [package.metadata.deb]
 # $auto doesn't work because we don't build packages in the same container as we build the binaries.
-depends = "adduser, libssl1.1, libc6"
+depends = "adduser, libc6"
 section = "net"
 maintainer-scripts = "debian-scripts"
 conf-files = ["/etc/homie-influx/homie-influx.toml", "/etc/homie-influx/mappings.toml"]

--- a/homie-influx/Cargo.toml
+++ b/homie-influx/Cargo.toml
@@ -14,7 +14,7 @@ color-backtrace = "0.5.0"
 eyre = "0.6.5"
 futures = "0.3.8"
 homie-controller = { version = "0.3.0", path = "../homie-controller" }
-influx_db_client = "0.4.5"
+influx_db_client = "0.5.0"
 log = "0.4.11"
 pretty_env_logger = "0.4.0"
 rumqttc = "0.4.0"
@@ -26,7 +26,6 @@ stable-eyre = "0.2.1"
 tokio = "1.0.1"
 toml = "0.5.8"
 url = { version = "2.2.0", features = ["serde"] }
-tokio-compat-02 = "0.2.0"
 
 [package.metadata.deb]
 # $auto doesn't work because we don't build packages in the same container as we build the binaries.

--- a/homie-influx/src/influx.rs
+++ b/homie-influx/src/influx.rs
@@ -2,7 +2,6 @@ use eyre::WrapErr;
 use homie_controller::{Datatype, Device, HomieController, Node, Property};
 use influx_db_client::{Client, Point, Precision, Value};
 use std::time::SystemTime;
-use tokio_compat_02::FutureExt;
 
 const INFLUXDB_PRECISION: Option<Precision> = Some(Precision::Milliseconds);
 
@@ -22,7 +21,6 @@ pub async fn send_property_value(
                     // Passing None for rp should use the default retention policy for the database.
                     influx_db_client
                         .write_point(point, INFLUXDB_PRECISION, None)
-                        .compat()
                         .await
                         .wrap_err("Failed to send property value update to InfluxDB")?;
                 }


### PR DESCRIPTION
This uses Tokio 1.0, so we no longer need tokio-compat-02. It also lets us use rustls rather than openssl.