### PR TITLE
Present boolean as integer for Grafana

### DIFF
--- a/homie-influx/README.md
+++ b/homie-influx/README.md
@@ -54,6 +54,17 @@ You may find it helpful to watch the logs to see whether it is managing to conne
 $ sudo journalctl -u homie-influx.service --output=cat --follow
 ```
 
+
+## Format
+
+This service publishes up to six measurements: `integer`, `float`, `boolean`, `string`, `enum`, `color`,
+corresponding to the Homie datatypes. Each message is published as an InfluxDB point with the appropriate
+name and timestamp, the value as a `value` field, and device / node / property info included as tags.
+
+In order to support Grafana clients, boolean points also have an additional `value_int` field,
+which is an integer, 1 for true or 0 for false.
+
+
 ## License
 
 Licensed under either of

--- a/homie-influx/README.md
+++ b/homie-influx/README.md
@@ -54,16 +54,15 @@ You may find it helpful to watch the logs to see whether it is managing to conne
 $ sudo journalctl -u homie-influx.service --output=cat --follow
 ```
 
-
 ## Format
 
-This service publishes up to six measurements: `integer`, `float`, `boolean`, `string`, `enum`, `color`,
-corresponding to the Homie datatypes. Each message is published as an InfluxDB point with the appropriate
-name and timestamp, the value as a `value` field, and device / node / property info included as tags.
+This service publishes up to six measurements: `integer`, `float`, `boolean`, `string`, `enum`,
+`color`, corresponding to the Homie datatypes. Each message is published as an InfluxDB point with
+the appropriate name and timestamp, the value as a `value` field, and device / node / property info
+included as tags.
 
-In order to support Grafana clients, boolean points also have an additional `value_int` field,
-which is an integer, 1 for true or 0 for false.
-
+In order to support Grafana clients, boolean points also have an additional `value_int` field, which
+is an integer, 1 for true or 0 for false.
 
 ## License
 

--- a/homie-influx/src/influx.rs
+++ b/homie-influx/src/influx.rs
@@ -80,8 +80,7 @@ fn point_for_property_value(
         point = point.add_tag("node_type", Value::String(node_type))
     }
     if let Some(Datatype::Boolean) = property.datatype {
-        // Grafana is unable to display booleans directly,
-        // so add an integer for convenience.
+        // Grafana is unable to display booleans directly, so add an integer for convenience.
         // https://github.com/grafana/grafana/issues/8152
         // https://github.com/grafana/grafana/issues/24929
         point = point.add_field(


### PR DESCRIPTION
Grafana can't do anything useful with boolean fields, so this PR adds an additional field `value_int` to any boolean measurements, setting it to `1` if the property is `true` and `0` if the property is `false`. The existing field `value` remains unchanged.

I've also added some documentation about the published measurements to the README.