### PR TITLE
bluez-async: Emit events for service data and services

### DIFF
--- a/bluez-async/src/device.rs
+++ b/bluez-async/src/device.rs
@@ -1,5 +1,5 @@
 use bluez_generated::OrgBluezDevice1Properties;
-use dbus::arg::{cast, RefArg, Variant};
+use dbus::arg::{cast, PropMap, RefArg, Variant};
 use dbus::Path;
 use std::collections::HashMap;
 use std::fmt::{self, Display, Formatter};
@@ -193,14 +193,7 @@ fn get_service_data(
     Some(convert_service_data(device_properties.service_data()?))
 }
 
-pub(crate) fn convert_service_data(
-    data: &HashMap<String, Variant<Box<dyn RefArg>>>,
-) -> HashMap<Uuid, Vec<u8>> {
-    // UUIDs don't get populated until we connect. Use:
-    //     "ServiceData": Variant(InternalDict { data: [
-    //         ("0000fe95-0000-1000-8000-00805f9b34fb", Variant([48, 88, 91, 5, 1, 23, 33, 215, 56, 193, 164, 40, 1, 0])
-    //     )], outer_sig: Signature("a{sv}") })
-    // instead.
+pub(crate) fn convert_service_data(data: &PropMap) -> HashMap<Uuid, Vec<u8>> {
     data.iter()
         .filter_map(|(k, v)| match Uuid::parse_str(k) {
             Ok(uuid) => {

--- a/bluez-async/src/device.rs
+++ b/bluez-async/src/device.rs
@@ -190,49 +190,55 @@ pub(crate) fn convert_manufacturer_data(
 fn get_service_data(
     device_properties: OrgBluezDevice1Properties,
 ) -> Option<HashMap<Uuid, Vec<u8>>> {
+    Some(convert_service_data(device_properties.service_data()?))
+}
+
+pub(crate) fn convert_service_data(
+    data: &HashMap<String, Variant<Box<dyn RefArg>>>,
+) -> HashMap<Uuid, Vec<u8>> {
     // UUIDs don't get populated until we connect. Use:
     //     "ServiceData": Variant(InternalDict { data: [
     //         ("0000fe95-0000-1000-8000-00805f9b34fb", Variant([48, 88, 91, 5, 1, 23, 33, 215, 56, 193, 164, 40, 1, 0])
     //     )], outer_sig: Signature("a{sv}") })
     // instead.
-    Some(
-        device_properties
-            .service_data()?
-            .iter()
-            .filter_map(|(k, v)| match Uuid::parse_str(k) {
-                Ok(uuid) => {
-                    if let Some(v) = cast::<Vec<u8>>(&v.0) {
-                        Some((uuid, v.to_owned()))
-                    } else {
-                        log::warn!("Service data had wrong type: {:?}", &v.0);
-                        None
-                    }
-                }
-                Err(err) => {
-                    log::warn!("Error parsing service data UUID: {}", err);
+    data.iter()
+        .filter_map(|(k, v)| match Uuid::parse_str(k) {
+            Ok(uuid) => {
+                if let Some(v) = cast::<Vec<u8>>(&v.0) {
+                    Some((uuid, v.to_owned()))
+                } else {
+                    log::warn!("Service data had wrong type: {:?}", &v.0);
                     None
                 }
-            })
-            .collect(),
-    )
+            }
+            Err(err) => {
+                log::warn!("Error parsing service data UUID: {}", err);
+                None
+            }
+        })
+        .collect()
 }
 
 fn get_services(device_properties: OrgBluezDevice1Properties) -> Vec<Uuid> {
     if let Some(uuids) = device_properties.uuids() {
-        uuids
-            .iter()
-            .filter_map(|uuid| {
-                Uuid::parse_str(uuid)
-                    .map_err(|err| {
-                        log::warn!("Error parsing service data UUID: {}", err);
-                        err
-                    })
-                    .ok()
-            })
-            .collect()
+        convert_services(uuids)
     } else {
         vec![]
     }
+}
+
+pub(crate) fn convert_services(uuids: &Vec<String>) -> Vec<Uuid> {
+    uuids
+        .iter()
+        .filter_map(|uuid| {
+            Uuid::parse_str(uuid)
+                .map_err(|err| {
+                    log::warn!("Error parsing service data UUID: {}", err);
+                    err
+                })
+                .ok()
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/bluez-async/src/events.rs
+++ b/bluez-async/src/events.rs
@@ -61,14 +61,19 @@ pub enum DeviceEvent {
     RSSI { rssi: i16 },
     /// A new value is available for the manufacturer-specific advertisement data of the device.
     ManufacturerData {
+        /// The manufacturer-specific advertisement data. The keys are 'manufacturer IDs'.
         manufacturer_data: HashMap<u16, Vec<u8>>,
     },
-    /// New service-specific advertisement data is available for the device.
+    /// New GATT service advertisement data is available for the device.
     ServiceData {
+        /// The new GATT service data. This is a map from the service UUID to its data.
         service_data: HashMap<Uuid, Vec<u8>>,
     },
-    /// These services have been advertised on the device.
-    Services { services: Vec<Uuid> },
+    /// The set of GATT services known for the device has changed.
+    Services {
+        /// The new set of GATT service UUIDs from the device's advertisement or service discovery.
+        services: Vec<Uuid>,
+    },
     /// Service discovery has completed.
     ServicesResolved,
 }


### PR DESCRIPTION
When the advertised services for a device are updated, a `DeviceEvent::Services` will be emitted. Same for `DeviceEvent::ServiceData` much like Manufacturer Data already does.

This PR will hopefully allow the use of `bluez-async` in https://github.com/deviceplug/btleplug/pull/114 to keep existing behaviour in regards to advertisements. 