### PR TITLE
Use PropMap where possible.

### DIFF
--- a/bluez-async/src/adapter.rs
+++ b/bluez-async/src/adapter.rs
@@ -87,7 +87,7 @@ impl AdapterInfo {
 
 #[cfg(test)]
 mod tests {
-    use dbus::arg::{RefArg, Variant};
+    use dbus::arg::{PropMap, Variant};
     use std::collections::HashMap;
 
     use super::*;
@@ -95,7 +95,7 @@ mod tests {
     #[test]
     fn adapter_info_minimal() {
         let id = AdapterId::new("/org/bluez/hci0");
-        let mut adapter_properties: HashMap<String, Variant<Box<dyn RefArg>>> = HashMap::new();
+        let mut adapter_properties: PropMap = HashMap::new();
         adapter_properties.insert(
             "Address".to_string(),
             Variant(Box::new("00:11:22:33:44:55".to_string())),

--- a/bluez-async/src/device.rs
+++ b/bluez-async/src/device.rs
@@ -250,9 +250,9 @@ mod tests {
     #[test]
     fn service_data() {
         let uuid = uuid_from_u32(0x11223344);
-        let mut service_data: HashMap<String, Variant<Box<dyn RefArg>>> = HashMap::new();
+        let mut service_data: PropMap = HashMap::new();
         service_data.insert(uuid.to_string(), Variant(Box::new(vec![1u8, 2, 3])));
-        let mut device_properties: HashMap<String, Variant<Box<dyn RefArg>>> = HashMap::new();
+        let mut device_properties: PropMap = HashMap::new();
         device_properties.insert("ServiceData".to_string(), Variant(Box::new(service_data)));
 
         let mut expected_service_data = HashMap::new();
@@ -269,7 +269,7 @@ mod tests {
         let manufacturer_id = 0x1122;
         let mut manufacturer_data: HashMap<u16, Variant<Box<dyn RefArg>>> = HashMap::new();
         manufacturer_data.insert(manufacturer_id, Variant(Box::new(vec![1u8, 2, 3])));
-        let mut device_properties: HashMap<String, Variant<Box<dyn RefArg>>> = HashMap::new();
+        let mut device_properties: PropMap = HashMap::new();
         device_properties.insert(
             "ManufacturerData".to_string(),
             Variant(Box::new(manufacturer_data)),
@@ -287,7 +287,7 @@ mod tests {
     #[test]
     fn device_info_minimal() {
         let id = DeviceId::new("/org/bluez/hci0/dev_11_22_33_44_55_66");
-        let mut device_properties: HashMap<String, Variant<Box<dyn RefArg>>> = HashMap::new();
+        let mut device_properties: PropMap = HashMap::new();
         device_properties.insert(
             "Address".to_string(),
             Variant(Box::new("00:11:22:33:44:55".to_string())),
@@ -325,7 +325,7 @@ mod tests {
 
     #[test]
     fn get_services_none() {
-        let device_properties: HashMap<String, Variant<Box<dyn RefArg>>> = HashMap::new();
+        let device_properties: PropMap = HashMap::new();
 
         assert_eq!(
             get_services(OrgBluezDevice1Properties(&device_properties)),
@@ -337,7 +337,7 @@ mod tests {
     fn get_services_some() {
         let uuid = uuid_from_u32(0x11223344);
         let uuids = vec![uuid.to_string()];
-        let mut device_properties: HashMap<String, Variant<Box<dyn RefArg>>> = HashMap::new();
+        let mut device_properties: PropMap = HashMap::new();
         device_properties.insert("UUIDs".to_string(), Variant(Box::new(uuids)));
 
         assert_eq!(

--- a/bluez-async/src/events.rs
+++ b/bluez-async/src/events.rs
@@ -251,7 +251,7 @@ impl BluetoothEvent {
 mod tests {
     use super::super::ServiceId;
     use crate::uuid_from_u32;
-    use dbus::arg::{RefArg, Variant};
+    use dbus::arg::{PropMap, RefArg, Variant};
 
     use super::*;
 
@@ -461,7 +461,7 @@ mod tests {
     }
 
     fn adapter_powered_message(adapter_path: &'static str, powered: bool) -> Message {
-        let mut changed_properties: HashMap<String, Variant<Box<dyn RefArg>>> = HashMap::new();
+        let mut changed_properties: PropMap = HashMap::new();
         changed_properties.insert("Powered".to_string(), Variant(Box::new(powered)));
         let properties_changed = PropertiesPropertiesChanged {
             interface_name: "org.bluez.Adapter1".to_string(),
@@ -472,7 +472,7 @@ mod tests {
     }
 
     fn device_rssi_message(device_path: &'static str, rssi: i16) -> Message {
-        let mut changed_properties: HashMap<String, Variant<Box<dyn RefArg>>> = HashMap::new();
+        let mut changed_properties: PropMap = HashMap::new();
         changed_properties.insert("RSSI".to_string(), Variant(Box::new(rssi)));
         let properties_changed = PropertiesPropertiesChanged {
             interface_name: "org.bluez.Device1".to_string(),
@@ -490,7 +490,7 @@ mod tests {
             .into_iter()
             .map::<(u16, Variant<Box<dyn RefArg>>), _>(|(k, v)| (k, Variant(Box::new(v))))
             .collect();
-        let mut changed_properties: HashMap<String, Variant<Box<dyn RefArg>>> = HashMap::new();
+        let mut changed_properties: PropMap = HashMap::new();
         changed_properties.insert(
             "ManufacturerData".to_string(),
             Variant(Box::new(manufacturer_data)),
@@ -539,7 +539,7 @@ mod tests {
     }
 
     fn characteristic_value_message(characteristic_path: &'static str, value: &[u8]) -> Message {
-        let mut changed_properties: HashMap<String, Variant<Box<dyn RefArg>>> = HashMap::new();
+        let mut changed_properties: PropMap = HashMap::new();
         changed_properties.insert("Value".to_string(), Variant(Box::new(value.to_owned())));
         let properties_changed = PropertiesPropertiesChanged {
             interface_name: "org.bluez.GattCharacteristic1".to_string(),


### PR DESCRIPTION
This is a type alias provided by `dbus` that makes things a bit less verbose.