### PR TITLE
Upload Debian packages to JFrog Artifactory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,4 +26,7 @@ jobs:
           regex: "^([a-z0-9-]+)_([0-9.-]+)_([a-z0-9]+).deb$"
       - name: Upload deb package to Artifactory
         if: ${{ steps.parse_filename.outputs.match != '' }}
-        run: curl -H"Authorization: Bearer ${{ secrets.JFROG_TOKEN }}" -XPUT "https://homiers.jfrog.io/artifactory/homie-rs/pool/${{ steps.parse_filename.outputs.group1 }};deb.distribution=stable;deb.component=main;deb.architecture=${{ steps.parse_filename.outputs.group3 }}" -T "${{ matrix.asset.name }}"
+        run: >
+          curl -H"Authorization: Bearer ${{ secrets.JFROG_TOKEN }}"
+          -XPUT "https://homiers.jfrog.io/artifactory/homie-rs/pool/${{ steps.parse_filename.outputs.group1 }};deb.distribution=stable;deb.component=main;deb.architecture=${{ steps.parse_filename.outputs.group3 }}"
+          -T "${{ matrix.asset.name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,10 @@ jobs:
         uses: actions-ecosystem/action-regex-match@v2
         with:
           text: ${{ matrix.asset.name }}
-          regex: "^([a-z0-9-]+)_([0-9.-]+)_([a-z0-9]+).deb$"
+          regex: "^[a-z0-9-]+_[0-9.-]+_([a-z0-9]+).deb$"
       - name: Upload deb package to Artifactory
         if: ${{ steps.parse_filename.outputs.match != '' }}
         run: >
           curl -H"Authorization: Bearer ${{ secrets.JFROG_TOKEN }}"
-          -XPUT "https://homiers.jfrog.io/artifactory/homie-rs/pool/${{ steps.parse_filename.outputs.group1 }};deb.distribution=stable;deb.component=main;deb.architecture=${{ steps.parse_filename.outputs.group3 }}"
+          -XPUT "https://homiers.jfrog.io/artifactory/homie-rs/pool/${{ matrix.asset.name }};deb.distribution=stable;deb.component=main;deb.architecture=${{ steps.parse_filename.outputs.group1 }}"
           -T "${{ matrix.asset.name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,20 +24,6 @@ jobs:
         with:
           text: ${{ matrix.asset.name }}
           regex: "^([a-z0-9-]+)_([0-9.-]+)_([a-z0-9]+).deb$"
-      - name: Upload deb package to Bintray
+      - name: Upload deb package to Artifactory
         if: ${{ steps.parse_filename.outputs.match != '' }}
-        uses: bpicode/github-action-upload-bintray@master
-        with:
-          file: ${{ matrix.asset.name }}
-          api_user: alsuren
-          api_key: ${{ secrets.BINTRAY_API_KEY }}
-          repository_user: homie-rs
-          repository: homie-rs
-          package: ${{ steps.parse_filename.outputs.group1 }}
-          version: ${{ steps.parse_filename.outputs.group2 }}
-          upload_path: pool/stable/main
-          publish: 1
-          calculate_metadata: true # Schedule metadata calculation after upload
-          deb_distribution: stable
-          deb_component: main
-          deb_architecture: ${{ steps.parse_filename.outputs.group3 }}
+        run: curl -H"Authorization: Bearer ${{ secrets.JFROG_TOKEN }}" -XPUT "https://homiers.jfrog.io/artifactory/homie-rs/pool/${{ steps.parse_filename.outputs.group1 }};deb.distribution=stable;deb.component=main;deb.architecture=${{ steps.parse_filename.outputs.group3 }}" -T "${{ matrix.asset.name }}"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -6,4 +6,4 @@ To release a new version of `mijia-homie`:
 2. Tag the commit which merges this to `master` to match the new version, like `mijia-homie-x.y.z`, and push to the repository.
 3. Wait for the [Package workflow](https://github.com/alsuren/mijia-homie/actions?query=workflow%3APackage) to create a new draft [release](https://github.com/alsuren/mijia-homie/releases) including the Debian packages.
 4. Edit the release, add an appropriate description, and then publish it.
-5. As soon as the release is published, the packages should automatically be pushed to the [Bintray repository](https://bintray.com/alsuren/mijia-homie) by the [Release workflow](https://github.com/alsuren/mijia-homie/actions?query=workflow%3ARelease).
+5. As soon as the release is published, the packages should automatically be pushed to the [Artifactory repository](https://homiers.jfrog.io/) by the [Release workflow](https://github.com/alsuren/mijia-homie/actions?query=workflow%3ARelease).

--- a/homie-influx/README.md
+++ b/homie-influx/README.md
@@ -1,7 +1,6 @@
 # Homie device InfluxDB logger
 
 [![crates.io page](https://img.shields.io/crates/v/homie-influx.svg)](https://crates.io/crates/homie-influx)
-[![Download](https://api.bintray.com/packages/homie-rs/homie-rs/homie-influx/images/download.svg) ](https://bintray.com/homie-rs/homie-rs/homie-influx/_latestVersion)
 
 `homie-influx` is a service to connect to an MQTT broker, discover devices following the
 [Homie convention](https://homieiot.github.io/), and record their property value changes to an
@@ -15,8 +14,8 @@ background.
 It is recommended to install the latest release from our Debian repository:
 
 ```sh
-$ curl -L https://bintray.com/user/downloadSubjectPublicKey?username=homie-rs | sudo apt-key add -
-$ echo "deb https://dl.bintray.com/homie-rs/homie-rs stable main" | sudo tee /etc/apt/sources.list.d/homie-rs.list
+$ curl -L https://homiers.jfrog.io/artifactory/api/security/keypair/public/repositories/homie-rs | sudo apt-key add -
+$ echo "deb https://homiers.jfrog.io/artifactory/homie-rs stable main" | sudo tee /etc/apt/sources.list.d/homie-rs.list
 $ sudo apt update && sudo apt install homie-influx
 ```
 

--- a/mijia-homie/README.md
+++ b/mijia-homie/README.md
@@ -1,7 +1,6 @@
 # Mijia sensor to Homie bridge
 
 [![crates.io page](https://img.shields.io/crates/v/mijia-homie.svg)](https://crates.io/crates/mijia-homie)
-[![Download](https://api.bintray.com/packages/homie-rs/homie-rs/mijia-homie/images/download.svg) ](https://bintray.com/homie-rs/homie-rs/mijia-homie/_latestVersion)
 
 `mijia-homie` is a service for connecting to Xiaomi Mijia 2 Bluetooth temperature/humidity sensors
 and publishing their readings to an MQTT broker following the
@@ -15,8 +14,8 @@ background.
 It is recommended to install the latest release from our Debian repository:
 
 ```sh
-$ curl -L https://bintray.com/user/downloadSubjectPublicKey?username=homie-rs | sudo apt-key add -
-$ echo "deb https://dl.bintray.com/homie-rs/homie-rs stable main" | sudo tee /etc/apt/sources.list.d/homie-rs.list
+$ curl -L https://homiers.jfrog.io/artifactory/api/security/keypair/public/repositories/homie-rs | sudo apt-key add -
+$ echo "deb https://homiers.jfrog.io/artifactory/homie-rs stable main" | sudo tee /etc/apt/sources.list.d/homie-rs.list
 $ sudo apt update && sudo apt install mijia-homie
 ```
 


### PR DESCRIPTION
Bintray went away some time ago, so let's try Artifactory instead. I can't see any easy way to test that the workflow actually works, but I have tried the upload command locally with the same credentials and that works at least.