### PR TITLE
Use latest version of cargo-deb.

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -66,9 +66,15 @@ jobs:
           command: build
           args: --release --target ${{ matrix.target }}
       - name: Package homie-influx
-        run: cargo deb --target ${{ matrix.target }} --no-build --package homie-influx
+        uses: actions-rs/cargo@v1
+        with:
+          command: deb
+          args: --target ${{ matrix.target }} --no-build --package homie-influx
       - name: Package mijia-homie
-        run: cargo deb --target ${{ matrix.target }} --no-build --package mijia-homie
+        uses: actions-rs/cargo@v1
+        with:
+          command: deb
+          args: --target ${{ matrix.target }} --no-build --package mijia-homie
 
       - name: Upload packages
         uses: actions/upload-artifact@v2

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -72,7 +72,7 @@ jobs:
         working-directory: mijia-homie
         run: cargo deb --target ${{ matrix.target }} --no-build
 
-      - name: Upload package
+      - name: Upload packages
         uses: actions/upload-artifact@v2
         with:
           name: debian-packages

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  cargo-deb-version: 1.28.0
+  cargo-deb-version: 1.34.2
 
 jobs:
   build:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -66,11 +66,9 @@ jobs:
           command: build
           args: --release --target ${{ matrix.target }}
       - name: Package homie-influx
-        working-directory: homie-influx
-        run: cargo deb --target ${{ matrix.target }} --no-build
+        run: cargo deb --target ${{ matrix.target }} --no-build --package homie-influx
       - name: Package mijia-homie
-        working-directory: mijia-homie
-        run: cargo deb --target ${{ matrix.target }} --no-build
+        run: cargo deb --target ${{ matrix.target }} --no-build --package mijia-homie
 
       - name: Upload packages
         uses: actions/upload-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  cargo-deb-version: 1.28.0
 
 jobs:
   push:


### PR DESCRIPTION
The workspace directory bug was fixed in https://github.com/mmstick/cargo-deb/issues/151.