### PR TITLE
Handle reconnection better

### DIFF
--- a/homie-controller/CHANGELOG.md
+++ b/homie-controller/CHANGELOG.md
@@ -7,6 +7,7 @@
 - It is no longer necessary to call `HomieController::start`, it has been removed from the public
   API. If the MQTT connection is dropped and reconnected the necessary subscriptions will
   automatically be set up again, without the need for a persistent session.
+- Added new `Event::Connected`.
 
 ## 0.4.0
 

--- a/homie-controller/CHANGELOG.md
+++ b/homie-controller/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Breaking changes
+
+- It is no longer necessary to call `HomieController::start`, it has been removed from the public
+  API. If the MQTT connection is dropped and reconnected the necessary subscriptions will
+  automatically be set up again, without the need for a persistent session.
+
 ## 0.4.0
 
 ### Breaking changes

--- a/homie-controller/examples/discover.rs
+++ b/homie-controller/examples/discover.rs
@@ -11,7 +11,6 @@ async fn main() -> Result<(), PollError> {
     mqttoptions.set_keep_alive(5);
 
     let (controller, mut event_loop) = HomieController::new(mqttoptions, "homie");
-    controller.start().await?;
     loop {
         match controller.poll(&mut event_loop).await {
             Ok(Some(Event::PropertyValueChanged {

--- a/homie-controller/examples/discover.rs
+++ b/homie-controller/examples/discover.rs
@@ -7,7 +7,8 @@ use rumqttc::MqttOptions;
 async fn main() -> Result<(), PollError> {
     pretty_env_logger::init();
 
-    let mqttoptions = MqttOptions::new("homie_controller", "test.mosquitto.org", 1883);
+    let mut mqttoptions = MqttOptions::new("homie_controller", "test.mosquitto.org", 1883);
+    mqttoptions.set_keep_alive(5);
 
     let (controller, mut event_loop) = HomieController::new(mqttoptions, "homie");
     controller.start().await?;

--- a/homie-controller/examples/discover.rs
+++ b/homie-controller/examples/discover.rs
@@ -13,32 +13,32 @@ async fn main() -> Result<(), PollError> {
     let (controller, mut event_loop) = HomieController::new(mqttoptions, "homie");
     controller.start().await?;
     loop {
-        if let Some(event) = controller.poll(&mut event_loop).await? {
-            match event {
-                Event::PropertyValueChanged {
-                    device_id,
-                    node_id,
-                    property_id,
-                    value,
-                    fresh,
-                } => {
-                    println!(
-                        "{}/{}/{} = {} ({})",
-                        device_id, node_id, property_id, value, fresh
-                    );
-                }
-                _ => {
-                    println!("Event: {:?}", event);
-                    println!("Devices:");
-                    for device in controller.devices().values() {
-                        if device.has_required_attributes() {
-                            println!(" * {:?}", device);
-                        } else {
-                            println!(" * {} not ready.", device.id);
-                        }
+        match controller.poll(&mut event_loop).await {
+            Ok(Some(Event::PropertyValueChanged {
+                device_id,
+                node_id,
+                property_id,
+                value,
+                fresh,
+            })) => {
+                println!(
+                    "{}/{}/{} = {} ({})",
+                    device_id, node_id, property_id, value, fresh
+                );
+            }
+            Ok(Some(event)) => {
+                println!("Event: {:?}", event);
+                println!("Devices:");
+                for device in controller.devices().values() {
+                    if device.has_required_attributes() {
+                        println!(" * {:?}", device);
+                    } else {
+                        println!(" * {} not ready.", device.id);
                     }
                 }
             }
+            Ok(None) => {}
+            Err(e) => log::error!("Error: {:?}", e),
         }
     }
 }

--- a/homie-controller/examples/flash.rs
+++ b/homie-controller/examples/flash.rs
@@ -47,7 +47,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let (controller, event_loop) = HomieController::new(mqttoptions, "homie");
     let controller = Arc::new(controller);
     let handle = spawn_poll_loop(event_loop, controller.clone());
-    controller.start().await?;
 
     for _ in 0..3 {
         for &value in [true, false].iter() {

--- a/homie-controller/src/lib.rs
+++ b/homie-controller/src/lib.rs
@@ -172,7 +172,6 @@ impl HomieController {
     }
 
     async fn handle_event(&self, incoming: Incoming) -> Result<Option<Event>, PollError> {
-        log::trace!("Incoming: {:?}", incoming);
         if let Incoming::Publish(publish) = incoming {
             match self.handle_publish(publish).await {
                 Err(HandleError::Warning(err)) => {

--- a/homie-controller/tests/integration.rs
+++ b/homie-controller/tests/integration.rs
@@ -31,7 +31,6 @@ async fn test_device() {
     // Start controller.
     let controller_options = MqttOptions::new("homie_controller", "localhost", PORT);
     let (controller, mut event_loop) = HomieController::new(controller_options, "homie");
-    controller.start().await.unwrap();
 
     // Start device
     let (updates_tx, updates_rx) = mpsc::sync_channel(10);

--- a/homie-influx/src/config.rs
+++ b/homie-influx/src/config.rs
@@ -171,7 +171,6 @@ pub fn get_mqtt_options(
     let client_name = format!("{}-{}", config.client_prefix, client_name_suffix);
     let mut mqtt_options = MqttOptions::new(client_name, &config.host, config.port);
     mqtt_options.set_keep_alive(5);
-    mqtt_options.set_clean_session(false);
 
     if let (Some(username), Some(password)) = (&config.username, &config.password) {
         mqtt_options.set_credentials(username, password);

--- a/homie-influx/src/main.rs
+++ b/homie-influx/src/main.rs
@@ -46,7 +46,6 @@ async fn main() -> Result<(), eyre::Report> {
             influxdb_client,
             config.mqtt.reconnect_interval,
         );
-        controller.start().await?;
         join_handles.push(handle);
     }
 


### PR DESCRIPTION
Rather than relying on a persistent session to keep its subscriptions, the Homie controller should automatically re-subscribe after re-connection. This can be done by making the initial subscription in response to the MQTT `CONACK`.