### PR TITLE
Clear devices on reconnect rather than subscribing unconditionally.

### DIFF
--- a/homie-controller/CHANGELOG.md
+++ b/homie-controller/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Bugfixes
+
+- Fixed bug introducted in 0.5.0 which could result in an infinite loop of subscribing and receiving
+  messages.
+
 ## 0.5.0
 
 ### Breaking changes

--- a/homie-controller/src/lib.rs
+++ b/homie-controller/src/lib.rs
@@ -247,14 +247,12 @@ impl HomieController {
         let parts = subtopic.split('/').collect::<Vec<&str>>();
         let event = match parts.as_slice() {
             [device_id, "$homie"] => {
-                // Subscribe to topics even if we already know about the device, because this might
-                // be a reconnection.
-                topics_to_subscribe.push(format!("{}/{}/+", self.base_topic, device_id));
-                topics_to_subscribe.push(format!("{}/{}/$fw/+", self.base_topic, device_id));
-                topics_to_subscribe.push(format!("{}/{}/$stats/+", self.base_topic, device_id));
                 if !devices.contains_key(*device_id) {
                     log::trace!("Homie device '{}' version '{}'", device_id, payload);
                     devices.insert((*device_id).to_owned(), Device::new(device_id, payload));
+                    topics_to_subscribe.push(format!("{}/{}/+", self.base_topic, device_id));
+                    topics_to_subscribe.push(format!("{}/{}/$fw/+", self.base_topic, device_id));
+                    topics_to_subscribe.push(format!("{}/{}/$stats/+", self.base_topic, device_id));
                     Some(Event::DeviceUpdated {
                         device_id: (*device_id).to_owned(),
                         has_required_attributes: false,
@@ -386,9 +384,9 @@ impl HomieController {
                 for node_id in nodes {
                     if !device.nodes.contains_key(node_id) {
                         device.add_node(Node::new(node_id));
+                        let topic = format!("{}/{}/{}/+", self.base_topic, device_id, node_id);
+                        topics_to_subscribe.push(topic);
                     }
-                    let topic = format!("{}/{}/{}/+", self.base_topic, device_id, node_id);
-                    topics_to_subscribe.push(topic);
                 }
 
                 Some(Event::device_updated(device))
@@ -425,12 +423,12 @@ impl HomieController {
                 for property_id in properties {
                     if !node.properties.contains_key(property_id) {
                         node.add_property(Property::new(property_id));
+                        let topic = format!(
+                            "{}/{}/{}/{}/+",
+                            self.base_topic, device_id, node_id, property_id
+                        );
+                        topics_to_subscribe.push(topic);
                     }
-                    let topic = format!(
-                        "{}/{}/{}/{}/+",
-                        self.base_topic, device_id, node_id, property_id
-                    );
-                    topics_to_subscribe.push(topic);
                 }
 
                 Some(Event::node_updated(device_id, node))
@@ -551,6 +549,9 @@ impl HomieController {
 
     /// Start discovering Homie devices.
     async fn start(&self) -> Result<(), ClientError> {
+        // Clear set of known devices so that we correctly subscribe to their topics again.
+        *self.devices.lock().unwrap() = Arc::new(HashMap::new());
+
         let topic = format!("{}/+/$homie", self.base_topic);
         log::trace!("Subscribe to {}", topic);
         self.mqtt_client.subscribe(topic, QoS::AtLeastOnce).await

--- a/homie-influx/CHANGELOG.md
+++ b/homie-influx/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Bugfixes
+
+- Fixed bug introducted in 0.2.5 which could result in an infinite loop of subscribing and receiving
+  messages.
+
 ## 0.2.5
 
 ### Bugfixes


### PR DESCRIPTION
Subscribing unconditionally may result in a loop, where getting message for `homie/device/$homie` results in subscribing to `homie/device/+`, which may result in the broker sending the same message again.