### PR TITLE
controller: handle property values published before  (fixes #227)

### DIFF
--- a/homie-controller/examples/discover.rs
+++ b/homie-controller/examples/discover.rs
@@ -14,30 +14,33 @@ async fn main() -> Result<(), PollError> {
     let (controller, mut event_loop) = HomieController::new(mqttoptions, "homie");
     loop {
         match controller.poll(&mut event_loop).await {
-            Ok(Some(Event::PropertyValueChanged {
-                device_id,
-                node_id,
-                property_id,
-                value,
-                fresh,
-            })) => {
-                println!(
-                    "{}/{}/{} = {} ({})",
-                    device_id, node_id, property_id, value, fresh
-                );
-            }
-            Ok(Some(event)) => {
-                println!("Event: {:?}", event);
-                println!("Devices:");
-                for device in controller.devices().values() {
-                    if device.has_required_attributes() {
-                        println!(" * {:?}", device);
+            Ok(events) => {
+                for event in events {
+                    if let Event::PropertyValueChanged {
+                        device_id,
+                        node_id,
+                        property_id,
+                        value,
+                        fresh,
+                    } = event
+                    {
+                        println!(
+                            "{}/{}/{} = {} ({})",
+                            device_id, node_id, property_id, value, fresh
+                        );
                     } else {
-                        println!(" * {} not ready.", device.id);
+                        println!("Event: {:?}", event);
+                        println!("Devices:");
+                        for device in controller.devices().values() {
+                            if device.has_required_attributes() {
+                                println!(" * {:?}", device);
+                            } else {
+                                println!(" * {} not ready.", device.id);
+                            }
+                        }
                     }
                 }
             }
-            Ok(None) => {}
             Err(e) => log::error!("Error: {:?}", e),
         }
     }

--- a/homie-controller/examples/flash.rs
+++ b/homie-controller/examples/flash.rs
@@ -15,23 +15,21 @@ fn spawn_poll_loop(
 ) -> JoinHandle<Result<(), PollError>> {
     task::spawn(async move {
         loop {
-            if let Some(event) = controller.poll(&mut event_loop).await? {
-                match event {
-                    Event::PropertyValueChanged {
-                        device_id,
-                        node_id,
-                        property_id,
-                        value,
-                        fresh,
-                    } => {
-                        println!(
-                            "{}/{}/{} = {} ({})",
-                            device_id, node_id, property_id, value, fresh
-                        );
-                    }
-                    _ => {
-                        log::info!("Event: {:?}", event);
-                    }
+            for event in controller.poll(&mut event_loop).await? {
+                if let Event::PropertyValueChanged {
+                    device_id,
+                    node_id,
+                    property_id,
+                    value,
+                    fresh,
+                } = event
+                {
+                    println!(
+                        "{}/{}/{} = {} ({})",
+                        device_id, node_id, property_id, value, fresh
+                    );
+                } else {
+                    log::info!("Event: {:?}", event);
                 }
             }
         }

--- a/homie-controller/src/lib.rs
+++ b/homie-controller/src/lib.rs
@@ -115,6 +115,8 @@ pub struct HomieController {
     /// The set of Homie devices which have been discovered so far, keyed by their IDs.
     // TODO: Consider using Mutex<im::HashMap<...>> instead.
     devices: Mutex<Arc<HashMap<String, Device>>>,
+    /// temporarily holds retained property payloads that were received before their nodes'
+    /// $properties. The stored payloads are consumed when $properties is received.
     early_property_values: Mutex<HashMap<String, String>>,
 }
 
@@ -240,6 +242,7 @@ impl HomieController {
         // our Arc to point to that, so that it is now a unique reference.
         let devices = &mut *self.devices.lock().unwrap();
         let devices = Arc::make_mut(devices);
+
         let early_property_values = &mut *self.early_property_values.lock().unwrap();
 
         // Collect MQTT topics to which we need to subscribe or unsubscribe here, so that the

--- a/homie-controller/src/lib.rs
+++ b/homie-controller/src/lib.rs
@@ -115,7 +115,7 @@ pub struct HomieController {
     /// The set of Homie devices which have been discovered so far, keyed by their IDs.
     // TODO: Consider using Mutex<im::HashMap<...>> instead.
     devices: Mutex<Arc<HashMap<String, Device>>>,
-    early_property_values: Mutex<Option<HashMap<String, String>>>,
+    early_property_values: Mutex<HashMap<String, String>>,
 }
 
 pub struct HomieEventLoop {
@@ -148,7 +148,7 @@ impl HomieController {
             mqtt_client,
             base_topic: base_topic.to_string(),
             devices: Mutex::new(Arc::new(HashMap::new())),
-            early_property_values: Mutex::new(Some(HashMap::new())),
+            early_property_values: Mutex::new(HashMap::new()),
         };
         (controller, HomieEventLoop::new(event_loop))
     }
@@ -427,10 +427,8 @@ impl HomieController {
                     if !node.properties.contains_key(property_id) {
                         let mut new_prop = Property::new(property_id);
 
-                        new_prop.value = early_property_values.as_mut().and_then(|map| {
-                            let key = format!("{}/{}/{}", device_id, node_id, property_id);
-                            map.remove(&key)
-                        });
+                        let key = format!("{}/{}/{}", device_id, node_id, property_id);
+                        new_prop.value = early_property_values.remove(&key);
 
                         node.add_property(new_prop);
                         let topic = format!(
@@ -440,9 +438,6 @@ impl HomieController {
                         topics_to_subscribe.push(topic);
                     }
                 }
-
-                // drop temporary payload storage as soon as $properties was received
-                early_property_values.take();
 
                 Some(Event::node_updated(device_id, node))
             }
@@ -524,17 +519,14 @@ impl HomieController {
                     && !node_id.starts_with('$')
                     && !property_id.starts_with('$') =>
             {
-                match (
-                    get_mut_property_for(
-                        devices,
-                        "Got property value for",
-                        device_id,
-                        node_id,
-                        property_id,
-                    ),
-                    early_property_values,
+                match get_mut_property_for(
+                    devices,
+                    "Got property value for",
+                    device_id,
+                    node_id,
+                    property_id,
                 ) {
-                    (Ok(mut property), _) => {
+                    Ok(mut property) => {
                         property.value = Some(payload.to_owned());
                         Some(Event::property_value(
                             device_id,
@@ -544,7 +536,7 @@ impl HomieController {
                         ))
                     }
 
-                    (Err(_), Some(early_property_values)) if publish.retain => {
+                    Err(_) if publish.retain => {
                         // temporarily store payloads for unknown properties to prevent
                         // a race condition when the broker sends out the property
                         // payloads before $properties
@@ -562,7 +554,7 @@ impl HomieController {
                         })
                     }
 
-                    (Err(e), _) => return Err(e.into()),
+                    Err(e) => return Err(e.into()),
                 }
             }
             [_device_id, _node_id, _property_id, "set"] => {
@@ -713,7 +705,7 @@ mod tests {
             base_topic: "base_topic".to_owned(),
             mqtt_client,
             devices: Mutex::new(Arc::new(HashMap::new())),
-            early_property_values: Mutex::new(Some(HashMap::new())),
+            early_property_values: Mutex::new(HashMap::new()),
         };
         (controller, requests_rx)
     }

--- a/homie-controller/src/lib.rs
+++ b/homie-controller/src/lib.rs
@@ -831,7 +831,12 @@ mod tests {
         publish_retained(&controller, "base_topic/device_id/$homie", "4.0").await?;
 
         // Discover a node on the device.
-        publish_retained(&controller, "base_topic/device_id/$nodes", "node_id").await?;
+        publish_retained(
+            &controller,
+            "base_topic/device_id/$nodes",
+            "node_id,second_node",
+        )
+        .await?;
 
         // Get the property payload before $properties
         publish_retained(
@@ -845,6 +850,21 @@ mod tests {
         publish_retained(
             &controller,
             "base_topic/device_id/node_id/$properties",
+            "property_id",
+        )
+        .await?;
+
+        publish_retained(
+            &controller,
+            "base_topic/device_id/second_node/property_id",
+            "hello again",
+        )
+        .await?;
+
+        // discover the property after its payload
+        publish_retained(
+            &controller,
+            "base_topic/device_id/second_node/$properties",
             "property_id",
         )
         .await?;
@@ -863,6 +883,22 @@ mod tests {
                 .value
                 .as_deref(),
             Some("HELLO WORLD")
+        );
+
+        assert_eq!(
+            controller
+                .devices()
+                .get("device_id")
+                .unwrap()
+                .nodes
+                .get("second_node")
+                .unwrap()
+                .properties
+                .get("property_id")
+                .unwrap()
+                .value
+                .as_deref(),
+            Some("hello again")
         );
 
         Ok(())

--- a/homie-controller/src/lib.rs
+++ b/homie-controller/src/lib.rs
@@ -115,7 +115,7 @@ pub struct HomieController {
     /// The set of Homie devices which have been discovered so far, keyed by their IDs.
     // TODO: Consider using Mutex<im::HashMap<...>> instead.
     devices: Mutex<Arc<HashMap<String, Device>>>,
-    early_property_values: Mutex<Arc<HashMap<String, String>>>,
+    early_property_values: Mutex<HashMap<String, String>>,
 }
 
 pub struct HomieEventLoop {
@@ -148,7 +148,7 @@ impl HomieController {
             mqtt_client,
             base_topic: base_topic.to_string(),
             devices: Mutex::new(Arc::new(HashMap::new())),
-            early_property_values: Mutex::new(Arc::new(HashMap::new())),
+            early_property_values: Mutex::new(HashMap::new()),
         };
         (controller, HomieEventLoop::new(event_loop))
     }
@@ -241,7 +241,6 @@ impl HomieController {
         let devices = &mut *self.devices.lock().unwrap();
         let devices = Arc::make_mut(devices);
         let early_property_values = &mut *self.early_property_values.lock().unwrap();
-        let early_property_values = Arc::make_mut(early_property_values);
 
         // Collect MQTT topics to which we need to subscribe or unsubscribe here, so that the
         // subscription can happen after the devices lock has been released.
@@ -704,7 +703,7 @@ mod tests {
             base_topic: "base_topic".to_owned(),
             mqtt_client,
             devices: Mutex::new(Arc::new(HashMap::new())),
-            early_property_values: Mutex::new(Arc::new(HashMap::new())),
+            early_property_values: Mutex::new(HashMap::new()),
         };
         (controller, requests_rx)
     }

--- a/homie-influx/src/main.rs
+++ b/homie-influx/src/main.rs
@@ -62,10 +62,11 @@ fn spawn_homie_poll_loop(
     task::spawn(async move {
         loop {
             match controller.poll(&mut event_loop).await {
-                Ok(Some(event)) => {
-                    handle_event(controller.as_ref(), &influx_db_client, event).await;
+                Ok(events) => {
+                    for event in events {
+                        handle_event(controller.as_ref(), &influx_db_client, event).await;
+                    }
                 }
-                Ok(None) => {}
                 Err(e) => {
                     log::error!(
                         "Failed to poll HomieController for base topic '{}': {}",


### PR DESCRIPTION
Alternative approach to #228.

Not sure how exactly the `Arc::make_mut` stuff works, I just followed the approach from the `devices` map.
I also don't really like the fact that I have to `format!` the lookup keys when handling `$properties` but I couldn't figure out how else to get tuples as keys working in this case.
Also note that this will indicate Event::PropertyValueChanged to the application even though the property itself wasn't yet discovered, as indicated by the comment around line 545