### PR TITLE
Add service to display sensor values on Raspberry Pi Rainbow Hat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ mijia-history-influx.toml
 mijia-homie.toml
 mappings.toml
 sensor-names.toml
+applehat.toml
 .DS_Store
 .vscode
 /notebooks/data

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,6 @@ dependencies = [
  "color-backtrace",
  "eyre",
  "futures",
- "futures-channel",
  "homie-controller",
  "homie-device",
  "log",
@@ -56,7 +55,6 @@ dependencies = [
  "stable-eyre",
  "tokio",
  "toml",
- "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,7 @@ dependencies = [
  "homie-device",
  "log",
  "pretty_env_logger",
+ "rainbow-hat-rs",
  "rumqttc",
  "rustls",
  "rustls-native-certs",
@@ -1312,6 +1313,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rainbow-hat-rs"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea5b95a2de692e97feefe0699e737a8d3a790f16d8d61eef81ba6e557febeeb"
+dependencies = [
+ "rppal",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1439,6 +1449,16 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "rppal"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb26758c881b4837b2f4aef569e4251f75388e36b37204e1804ef429c220121c"
+dependencies = [
+ "lazy_static",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,7 @@ dependencies = [
  "eyre",
  "futures",
  "futures-channel",
+ "homie-controller",
  "homie-device",
  "log",
  "pretty_env_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "applehat"
+version = "0.2.5"
+dependencies = [
+ "color-backtrace",
+ "eyre",
+ "futures",
+ "futures-channel",
+ "homie-device",
+ "log",
+ "pretty_env_logger",
+ "rumqttc",
+ "rustls",
+ "rustls-native-certs",
+ "serde",
+ "serde_derive",
+ "stable-eyre",
+ "tokio",
+ "toml",
+ "url",
+]
+
+[[package]]
 name = "argh"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 
 members = [
+    "applehat",
     "homie-controller",
     "homie-device",
     "homie-influx",

--- a/applehat/Cargo.toml
+++ b/applehat/Cargo.toml
@@ -13,7 +13,6 @@ categories = ["network-programming"]
 color-backtrace = "0.5.1"
 eyre = "0.6.8"
 futures = "0.3.25"
-futures-channel = "0.3.25"
 homie-controller = { version = "0.7.0", path = "../homie-controller" }
 homie-device = { version = "0.7.0", path = "../homie-device" }
 log = "0.4.17"
@@ -23,8 +22,7 @@ rumqttc = "0.18.0"
 rustls = "0.20.7"
 rustls-native-certs = "0.6.2"
 serde_derive = "1.0.137"
-serde = "1.0.148"
+serde = { version = "1.0.148", features = ["derive"] }
 stable-eyre = "0.2.2"
 tokio = { version = "1.22.0", features = ["macros", "rt-multi-thread"] }
 toml = "0.5.9"
-url = { version = "2.3.0", features = ["serde"] }

--- a/applehat/Cargo.toml
+++ b/applehat/Cargo.toml
@@ -26,3 +26,14 @@ serde = { version = "1.0.148", features = ["derive"] }
 stable-eyre = "0.2.2"
 tokio = { version = "1.22.0", features = ["macros", "rt-multi-thread"] }
 toml = "0.5.9"
+
+[package.metadata.deb]
+# $auto doesn't work because we don't build packages in the same container as we build the binaries.
+depends = "libc6"
+section = "net"
+conf-files = ["/etc/applehat/applehat.toml"]
+assets = [
+	["target/release/applehat", "usr/bin/", "755"],
+	["applehat.example.toml", "etc/applehat/applehat.toml", "640"],
+	["README.md", "usr/share/doc/applehat/", "644"],
+]

--- a/applehat/Cargo.toml
+++ b/applehat/Cargo.toml
@@ -18,6 +18,7 @@ homie-controller = { version = "0.7.0", path = "../homie-controller" }
 homie-device = { version = "0.7.0", path = "../homie-device" }
 log = "0.4.17"
 pretty_env_logger = "0.4.0"
+rainbow-hat-rs = "0.2.1"
 rumqttc = "0.18.0"
 rustls = "0.20.7"
 rustls-native-certs = "0.6.2"

--- a/applehat/Cargo.toml
+++ b/applehat/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "applehat"
+version = "0.2.5"
+authors = ["Andrew Walbran <qwandor@google.com>"]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Service to use a Rainbow HAT on a Raspberry Pi to show sensor data from Homie."
+repository = "https://github.com/alsuren/mijia-homie/"
+keywords = ["homie", "mqtt", "raspberrypi"]
+categories = ["network-programming"]
+
+[dependencies]
+color-backtrace = "0.5.1"
+eyre = "0.6.8"
+futures = "0.3.25"
+futures-channel = "0.3.25"
+homie-device = { version = "0.7.0", path = "../homie-device" }
+log = "0.4.17"
+pretty_env_logger = "0.4.0"
+rumqttc = "0.18.0"
+rustls = "0.20.7"
+rustls-native-certs = "0.6.2"
+serde_derive = "1.0.137"
+serde = "1.0.148"
+stable-eyre = "0.2.2"
+tokio = { version = "1.22.0", features = ["macros", "rt-multi-thread"] }
+toml = "0.5.9"
+url = { version = "2.3.0", features = ["serde"] }

--- a/applehat/Cargo.toml
+++ b/applehat/Cargo.toml
@@ -14,6 +14,7 @@ color-backtrace = "0.5.1"
 eyre = "0.6.8"
 futures = "0.3.25"
 futures-channel = "0.3.25"
+homie-controller = { version = "0.7.0", path = "../homie-controller" }
 homie-device = { version = "0.7.0", path = "../homie-device" }
 log = "0.4.17"
 pretty_env_logger = "0.4.0"

--- a/applehat/README.md
+++ b/applehat/README.md
@@ -1,0 +1,51 @@
+# Applehat
+
+[![crates.io page](https://img.shields.io/crates/v/applehat.svg)](https://crates.io/crates/applehat)
+
+`applehat` is a service to use a Rainbow HAT on a Raspberry Pi to show data from sensors on an MQTT
+broker following the [Homie convention](https://homieiot.github.io/).
+
+## Installation
+
+It is recommended to install the latest released Debian package from our releases.
+
+Alternatively, you may install with cargo install, but that will require some more setup:
+
+```sh
+$ cargo install applehat
+```
+
+## Usage
+
+There should be a config file under `/etc/applehat`:
+
+- `applehat.toml` contains the main configuration for the service, such as which MQTT broker to
+  connect to. See [applehat.example.toml](applehat.example.toml) for an example of the settings that
+  are supported.
+
+After editing these config files you will need to restart the service:
+
+```sh
+$ sudo systemctl restart applehat.service
+```
+
+You may find it helpful to watch the logs to see whether it is managing to connect:
+
+```sh
+$ sudo journalctl -u applehat.service --output=cat --follow
+```
+
+## License
+
+Licensed under either of
+
+- [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+- [MIT license](http://opensource.org/licenses/MIT)
+
+at your option.
+
+## Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the
+work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any
+additional terms or conditions.

--- a/applehat/applehat.example.toml
+++ b/applehat/applehat.example.toml
@@ -1,0 +1,17 @@
+[homie]
+# The Homie base MQTT topic.
+prefix="homie"
+
+[mqtt]
+# The hostname of the MQTT broker to use.
+host="test.mosquitto.org"
+# The port number of the MQTT broker to use.
+port=1883
+# The client name to use when connecting to the MQTT broker.
+client_name="applehat"
+# The username with which to authenticate to the MQTT broker, if any.
+#username=""
+# The password with which to authenticate to the MQTT broker, if any.
+#password=""
+# Whether to use TLS for the connection to the MQTT broker.
+use_tls=false

--- a/applehat/src/config.rs
+++ b/applehat/src/config.rs
@@ -1,0 +1,112 @@
+use eyre::{Report, WrapErr};
+use rumqttc::{MqttOptions, Transport};
+use rustls::{ClientConfig, RootCertStore};
+use serde::Deserialize;
+use std::{fs::read_to_string, time::Duration};
+
+const DEFAULT_HOST: &str = "test.mosquitto.org";
+const DEFAULT_PORT: u16 = 1883;
+const DEFAULT_CLIENT_NAME: &str = "applehat";
+const DEFAULT_MQTT_PREFIX: &str = "homie";
+const CONFIG_FILENAME: &str = "applehat.toml";
+const KEEP_ALIVE: Duration = Duration::from_secs(5);
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct Config {
+    pub mqtt: MqttConfig,
+    pub homie: HomieConfig,
+}
+
+impl Config {
+    pub fn from_file() -> Result<Config, Report> {
+        Config::read(CONFIG_FILENAME)
+    }
+
+    fn read(filename: &str) -> Result<Config, Report> {
+        let config_file =
+            read_to_string(filename).wrap_err_with(|| format!("Reading {}", filename))?;
+        Ok(toml::from_str(&config_file)?)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct MqttConfig {
+    pub host: String,
+    pub port: u16,
+    pub use_tls: bool,
+    pub username: Option<String>,
+    pub password: Option<String>,
+    pub client_name: String,
+}
+
+impl Default for MqttConfig {
+    fn default() -> MqttConfig {
+        MqttConfig {
+            host: DEFAULT_HOST.to_owned(),
+            port: DEFAULT_PORT,
+            use_tls: false,
+            username: None,
+            password: None,
+            client_name: DEFAULT_CLIENT_NAME.to_owned(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct HomieConfig {
+    pub prefix: String,
+}
+
+impl Default for HomieConfig {
+    fn default() -> HomieConfig {
+        HomieConfig {
+            prefix: DEFAULT_MQTT_PREFIX.to_owned(),
+        }
+    }
+}
+
+/// Construct the `MqttOptions` for connecting to the MQTT broker based on configuration options or
+/// defaults.
+pub fn get_mqtt_options(config: MqttConfig) -> MqttOptions {
+    let mut mqtt_options = MqttOptions::new(config.client_name, config.host, config.port);
+
+    mqtt_options.set_keep_alive(KEEP_ALIVE);
+    if let (Some(username), Some(password)) = (config.username, config.password) {
+        mqtt_options.set_credentials(username, password);
+    }
+
+    if config.use_tls {
+        let mut root_store = RootCertStore::empty();
+        for cert in
+            rustls_native_certs::load_native_certs().expect("Failed to load platform certificates.")
+        {
+            root_store.add(&rustls::Certificate(cert.0)).unwrap();
+        }
+        let client_config = ClientConfig::builder()
+            .with_safe_defaults()
+            .with_root_certificates(root_store)
+            .with_no_client_auth();
+        mqtt_options.set_transport(Transport::tls_with_config(client_config.into()));
+    }
+    mqtt_options
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Parsing the example config file should not give any errors.
+    #[test]
+    fn example_config() {
+        Config::read("applehat.example.toml").unwrap();
+    }
+
+    /// Parsing an empty config file should not give any errors.
+    #[test]
+    fn empty_config() {
+        toml::from_str::<Config>("").unwrap();
+    }
+}

--- a/applehat/src/main.rs
+++ b/applehat/src/main.rs
@@ -30,13 +30,7 @@ async fn main() -> Result<(), Report> {
     let alphanum = Alphanum4::new()?;
     let mut pixels = APA102::new()?;
     pixels.setup()?;
-    let ui_state = UiState {
-        alphanum,
-        pixels,
-        selected_device_id: "mijia-bridge-cottagepi".to_string(),
-        selected_node_id: "A4C138E98330".to_string(),
-        selected_property_id: "temperature".to_string(),
-    };
+    let ui_state = UiState::new(alphanum, pixels);
 
     let handle =
         spawn_homie_poll_loop(event_loop, controller.clone(), ui_state, reconnect_interval);

--- a/applehat/src/main.rs
+++ b/applehat/src/main.rs
@@ -3,6 +3,7 @@ mod config;
 use config::{get_mqtt_options, Config};
 use eyre::Report;
 use homie_controller::{Event, HomieController, HomieEventLoop, PollError};
+use log::{error, info, trace};
 use rumqttc::ConnectionError;
 use std::{sync::Arc, time::Duration};
 use tokio::{
@@ -44,7 +45,7 @@ fn spawn_homie_poll_loop(
                     }
                 }
                 Err(e) => {
-                    log::error!(
+                    error!(
                         "Failed to poll HomieController for base topic '{}': {}",
                         controller.base_topic(),
                         e
@@ -67,7 +68,7 @@ async fn handle_event(controller: &HomieController, event: Event) {
             value,
             fresh,
         } => {
-            log::trace!(
+            trace!(
                 "{}/{}/{}/{} = {} ({})",
                 controller.base_topic(),
                 device_id,
@@ -81,7 +82,7 @@ async fn handle_event(controller: &HomieController, event: Event) {
             }
         }
         _ => {
-            log::info!("{} Event: {:?}", controller.base_topic(), event);
+            info!("{} Event: {:?}", controller.base_topic(), event);
         }
     }
 }

--- a/applehat/src/main.rs
+++ b/applehat/src/main.rs
@@ -89,7 +89,7 @@ async fn handle_event(controller: &HomieController, alphanum: &mut Alphanum4, ev
                 );
                 if property_id == "temperature" {
                     let buf = format!("{}", value);
-                    alphanum.print_str(&buf, true);
+                    print_str_decimal(alphanum, &buf);
                     if let Err(e) = alphanum.show() {
                         error!("Error displaying: {}", e);
                     }
@@ -98,6 +98,26 @@ async fn handle_event(controller: &HomieController, alphanum: &mut Alphanum4, ev
         }
         _ => {
             info!("{} Event: {:?}", controller.base_topic(), event);
+        }
+    }
+}
+
+fn print_str_decimal(alphanum: &mut Alphanum4, s: &str) {
+    let mut position = 0;
+    for c in s.chars() {
+        if c == '.' {
+            if position == 0 {
+                alphanum.set_digit(position, '0', true);
+                position += 1;
+            } else {
+                alphanum.set_decimal(position - 1, true);
+            }
+        } else {
+            alphanum.set_digit(position, c, false);
+            position += 1;
+        }
+        if position >= 4 {
+            break;
         }
     }
 }

--- a/applehat/src/main.rs
+++ b/applehat/src/main.rs
@@ -5,7 +5,7 @@ use config::{get_mqtt_options, Config};
 use eyre::Report;
 use homie_controller::{Event, HomieController, HomieEventLoop, PollError};
 use log::{error, info, trace};
-use rainbow_hat_rs::alphanum4::Alphanum4;
+use rainbow_hat_rs::{alphanum4::Alphanum4, apa102::APA102};
 use rumqttc::ConnectionError;
 use std::{sync::Arc, time::Duration};
 use tokio::{
@@ -28,8 +28,11 @@ async fn main() -> Result<(), Report> {
     let controller = Arc::new(controller);
 
     let alphanum = Alphanum4::new()?;
+    let mut pixels = APA102::new()?;
+    pixels.setup()?;
     let ui_state = UiState {
         alphanum,
+        pixels,
         selected_device_id: "mijia-bridge-cottagepi".to_string(),
         selected_node_id: "A4C138E98330".to_string(),
         selected_property_id: "temperature".to_string(),

--- a/applehat/src/main.rs
+++ b/applehat/src/main.rs
@@ -1,7 +1,14 @@
 mod config;
 
-use config::Config;
+use config::{get_mqtt_options, Config};
 use eyre::Report;
+use homie_controller::{Event, HomieController, HomieEventLoop, PollError};
+use rumqttc::ConnectionError;
+use std::{sync::Arc, time::Duration};
+use tokio::{
+    task::{self, JoinHandle},
+    time::sleep,
+};
 
 #[tokio::main]
 async fn main() -> Result<(), Report> {
@@ -11,5 +18,70 @@ async fn main() -> Result<(), Report> {
 
     let config = Config::from_file()?;
 
+    let reconnect_interval = config.mqtt.reconnect_interval;
+    let mqtt_options = get_mqtt_options(config.mqtt);
+    let (controller, event_loop) = HomieController::new(mqtt_options, &config.homie.prefix);
+    let controller = Arc::new(controller);
+
+    let handle = spawn_homie_poll_loop(event_loop, controller.clone(), reconnect_interval);
+
+    handle.await?;
+
     Ok(())
+}
+
+fn spawn_homie_poll_loop(
+    mut event_loop: HomieEventLoop,
+    controller: Arc<HomieController>,
+    reconnect_interval: Duration,
+) -> JoinHandle<()> {
+    task::spawn(async move {
+        loop {
+            match controller.poll(&mut event_loop).await {
+                Ok(events) => {
+                    for event in events {
+                        handle_event(controller.as_ref(), event).await;
+                    }
+                }
+                Err(e) => {
+                    log::error!(
+                        "Failed to poll HomieController for base topic '{}': {}",
+                        controller.base_topic(),
+                        e
+                    );
+                    if let PollError::Connection(ConnectionError::Io(_)) = e {
+                        sleep(reconnect_interval).await;
+                    }
+                }
+            }
+        }
+    })
+}
+
+async fn handle_event(controller: &HomieController, event: Event) {
+    match event {
+        Event::PropertyValueChanged {
+            device_id,
+            node_id,
+            property_id,
+            value,
+            fresh,
+        } => {
+            log::trace!(
+                "{}/{}/{}/{} = {} ({})",
+                controller.base_topic(),
+                device_id,
+                node_id,
+                property_id,
+                value,
+                fresh
+            );
+            if fresh {
+                println!("Fresh property value {}/{}/{}={}", device_id, node_id, property_id, value);
+            }
+        }
+        _ => {
+            log::info!("{} Event: {:?}", controller.base_topic(), event);
+        }
+    }
 }

--- a/applehat/src/main.rs
+++ b/applehat/src/main.rs
@@ -35,7 +35,11 @@ async fn main() -> Result<(), Report> {
     let mut pixels = APA102::new()?;
     pixels.setup()?;
     let buttons = Buttons::new()?;
-    let ui_state = Arc::new(Mutex::new(UiState::new(alphanum, pixels)));
+    let ui_state = Arc::new(Mutex::new(UiState::new(
+        controller.clone(),
+        alphanum,
+        pixels,
+    )));
 
     let handle = spawn_homie_poll_loop(
         event_loop,
@@ -102,7 +106,7 @@ fn handle_event(controller: &HomieController, ui_state: &Mutex<UiState>, event: 
                     "Fresh property value {}/{}/{}={}",
                     device_id, node_id, property_id, value
                 );
-                ui_state.lock().unwrap().update_display(controller);
+                ui_state.lock().unwrap().update_display();
             }
         }
         _ => {

--- a/applehat/src/main.rs
+++ b/applehat/src/main.rs
@@ -1,0 +1,15 @@
+mod config;
+
+use config::Config;
+use eyre::Report;
+
+#[tokio::main]
+async fn main() -> Result<(), Report> {
+    stable_eyre::install()?;
+    pretty_env_logger::init();
+    color_backtrace::install();
+
+    let config = Config::from_file()?;
+
+    Ok(())
+}

--- a/applehat/src/main.rs
+++ b/applehat/src/main.rs
@@ -103,7 +103,16 @@ async fn handle_event(controller: &HomieController, alphanum: &mut Alphanum4, ev
 }
 
 fn print_str_decimal(alphanum: &mut Alphanum4, s: &str) {
-    let mut position = 0;
+    let padding = 4usize.saturating_sub(if s.contains('.') {
+        s.len() - 1
+    } else {
+        s.len()
+    });
+    for position in 0..padding {
+        alphanum.set_digit(position, ' ', false);
+    }
+
+    let mut position = padding;
     for c in s.chars() {
         if c == '.' {
             if position == 0 {

--- a/applehat/src/main.rs
+++ b/applehat/src/main.rs
@@ -41,6 +41,9 @@ async fn main() -> Result<(), Report> {
         pixels,
     )));
 
+    // Display initial state.
+    ui_state.lock().unwrap().update_display();
+
     let handle = spawn_homie_poll_loop(
         event_loop,
         controller.clone(),

--- a/applehat/src/ui.rs
+++ b/applehat/src/ui.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use homie_controller::{Device, HomieController, Node, Property, State};
+use homie_controller::{Datatype, Device, HomieController, Node, Property, State};
 use log::error;
 use rainbow_hat_rs::{alphanum4::Alphanum4, apa102::APA102};
 
@@ -110,10 +110,15 @@ fn find_nodes(devices: &HashMap<String, Device>) -> Vec<(&str, &str, &Node)> {
     for (device_id, device) in devices {
         if device.state == State::Ready {
             for (node_id, node) in &device.nodes {
-                if node.properties.contains_key(TEMPERATURE_PROPERTY_ID)
-                    && node.properties.contains_key(HUMIDITY_PROPERTY_ID)
-                {
-                    nodes.push((device_id, node_id, node));
+                if let (Some(temperature_node), Some(humidity_node)) = (
+                    node.properties.get(TEMPERATURE_PROPERTY_ID),
+                    node.properties.get(HUMIDITY_PROPERTY_ID),
+                ) {
+                    if temperature_node.datatype == Some(Datatype::Float)
+                        && humidity_node.datatype == Some(Datatype::Integer)
+                    {
+                        nodes.push((device_id, node_id, node));
+                    }
                 }
             }
         }

--- a/applehat/src/ui.rs
+++ b/applehat/src/ui.rs
@@ -32,6 +32,25 @@ impl UiState {
     pub fn update_display(&mut self, controller: &HomieController) {
         let devices = controller.devices();
 
+        // Show first 7 nodes on RGB LEDs.
+        let nodes = find_nodes(&devices);
+        for i in 0..7 {
+            let (r, g, b) = if let Some((device_id, node_id, node)) = nodes.get(i) {
+                let selected = Some(*device_id) == self.selected_device_id.as_deref()
+                    && Some(*node_id) == self.selected_node_id.as_deref();
+                trace!("Showing node {:?}", node);
+                colour_for_node(node, selected)
+            } else {
+                (0, 0, 0)
+            };
+            // TODO: Fix set_pixel brightness to work.
+            self.pixels.pixels[i] = [r, g, b, (PIXEL_BRIGHTNESS * 31.0) as u8];
+            //self.pixels.set_pixel(i, r, g, b, PIXEL_BRIGHTNESS);
+        }
+        if let Err(e) = self.pixels.show() {
+            error!("Error setting RGB LEDs: {}", e);
+        }
+
         if let (Some(selected_device_id), Some(selected_node_id)) =
             (&self.selected_device_id, &self.selected_node_id)
         {
@@ -55,25 +74,6 @@ impl UiState {
         }
         if let Err(e) = self.alphanum.show() {
             error!("Error displaying: {}", e);
-        }
-
-        // Show first 7 nodes on RGB LEDs.
-        let nodes = find_nodes(&devices);
-        for i in 0..7 {
-            let (r, g, b) = if let Some((device_id, node_id, node)) = nodes.get(i) {
-                let selected = Some(*device_id) == self.selected_device_id.as_deref()
-                    && Some(*node_id) == self.selected_node_id.as_deref();
-                trace!("Showing node {:?}", node);
-                colour_for_node(node, selected)
-            } else {
-                (0, 0, 0)
-            };
-            // TODO: Fix set_pixel brightness to work.
-            self.pixels.pixels[i] = [r, g, b, (PIXEL_BRIGHTNESS * 31.0) as u8];
-            //self.pixels.set_pixel(i, r, g, b, PIXEL_BRIGHTNESS);
-        }
-        if let Err(e) = self.pixels.show() {
-            error!("Error setting RGB LEDs: {}", e);
         }
     }
 }

--- a/applehat/src/ui.rs
+++ b/applehat/src/ui.rs
@@ -82,7 +82,15 @@ impl UiState {
                 &self.selected_property_id,
             ) {
                 if let Some(value) = &property.value {
-                    print_str_decimal(&mut self.alphanum, &value);
+                    print_str_decimal(
+                        &mut self.alphanum,
+                        &value,
+                        if self.selected_property_id == HUMIDITY_PROPERTY_ID {
+                            Some('%')
+                        } else {
+                            None
+                        },
+                    );
                 } else {
                     self.alphanum.print_str("????", false);
                 }
@@ -159,8 +167,10 @@ fn get_property<'a>(
         .get(property_id)
 }
 
-fn print_str_decimal(alphanum: &mut Alphanum4, s: &str) {
-    let padding = 4usize.saturating_sub(if s.contains('.') {
+fn print_str_decimal(alphanum: &mut Alphanum4, s: &str, unit: Option<char>) {
+    let number_width = if unit.is_some() { 3usize } else { 4 };
+
+    let padding = number_width.saturating_sub(if s.contains('.') {
         s.len() - 1
     } else {
         s.len()
@@ -182,9 +192,13 @@ fn print_str_decimal(alphanum: &mut Alphanum4, s: &str) {
             alphanum.set_digit(position, c, false);
             position += 1;
         }
-        if position >= 4 {
+        if position >= number_width {
             break;
         }
+    }
+
+    if let Some(unit) = unit {
+        alphanum.set_digit(3, unit, false);
     }
 }
 

--- a/applehat/src/ui.rs
+++ b/applehat/src/ui.rs
@@ -1,0 +1,79 @@
+use std::collections::HashMap;
+
+use homie_controller::{Device, HomieController, Property};
+use log::error;
+use rainbow_hat_rs::alphanum4::Alphanum4;
+
+#[derive(Debug)]
+pub struct UiState {
+    pub selected_device_id: String,
+    pub selected_node_id: String,
+    pub selected_property_id: String,
+    pub alphanum: Alphanum4,
+}
+
+impl UiState {
+    /// Updates the display based on the current state.
+    pub fn update_display(&mut self, controller: &HomieController) {
+        if let Some(property) = get_property(
+            &controller.devices(),
+            &self.selected_device_id,
+            &self.selected_node_id,
+            &self.selected_property_id,
+        ) {
+            if let Some(value) = &property.value {
+                print_str_decimal(&mut self.alphanum, &value);
+            } else {
+                self.alphanum.print_str("????", false);
+            }
+        } else {
+            self.alphanum.print_str("gone", false);
+        }
+        if let Err(e) = self.alphanum.show() {
+            error!("Error displaying: {}", e);
+        }
+    }
+}
+
+fn get_property<'a>(
+    devices: &'a HashMap<String, Device>,
+    device_id: &str,
+    node_id: &str,
+    property_id: &str,
+) -> Option<&'a Property> {
+    devices
+        .get(device_id)?
+        .nodes
+        .get(node_id)?
+        .properties
+        .get(property_id)
+}
+
+fn print_str_decimal(alphanum: &mut Alphanum4, s: &str) {
+    let padding = 4usize.saturating_sub(if s.contains('.') {
+        s.len() - 1
+    } else {
+        s.len()
+    });
+    for position in 0..padding {
+        alphanum.set_digit(position, ' ', false);
+    }
+
+    let mut position = padding;
+    for c in s.chars() {
+        if c == '.' {
+            if position == 0 {
+                alphanum.set_digit(position, '0', true);
+                position += 1;
+            } else {
+                alphanum.set_decimal(position - 1, true);
+            }
+        } else {
+            alphanum.set_digit(position, c, false);
+            position += 1;
+        }
+        if position >= 4 {
+            break;
+        }
+    }
+}

--- a/applehat/src/ui.rs
+++ b/applehat/src/ui.rs
@@ -19,17 +19,19 @@ const BUTTON_POLL_PERIOD: Duration = Duration::from_millis(100);
 
 #[derive(Debug)]
 pub struct UiState {
-    pub alphanum: Alphanum4,
-    pub pixels: APA102,
-    pub selected_device_id: Option<String>,
-    pub selected_node_id: Option<String>,
-    pub selected_property_id: String,
-    pub button_state: [bool; 3],
+    controller: Arc<HomieController>,
+    alphanum: Alphanum4,
+    pixels: APA102,
+    selected_device_id: Option<String>,
+    selected_node_id: Option<String>,
+    selected_property_id: String,
+    button_state: [bool; 3],
 }
 
 impl UiState {
-    pub fn new(alphanum: Alphanum4, pixels: APA102) -> Self {
+    pub fn new(controller: Arc<HomieController>, alphanum: Alphanum4, pixels: APA102) -> Self {
         Self {
+            controller,
             alphanum,
             pixels,
             selected_device_id: None,
@@ -40,8 +42,8 @@ impl UiState {
     }
 
     /// Updates the display based on the current state.
-    pub fn update_display(&mut self, controller: &HomieController) {
-        let devices = controller.devices();
+    pub fn update_display(&mut self) {
+        let devices = self.controller.devices();
 
         // Show first 7 nodes on RGB LEDs.
         let nodes = find_nodes(&devices);
@@ -112,6 +114,7 @@ impl UiState {
             }
             _ => {}
         }
+        self.update_display();
     }
 
     fn update_button_state(&mut self, new_state: [bool; 3]) {

--- a/applehat/src/ui.rs
+++ b/applehat/src/ui.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use homie_controller::{Datatype, Device, HomieController, Node, Property, State};
-use log::error;
+use log::{error, trace};
 use rainbow_hat_rs::{alphanum4::Alphanum4, apa102::APA102};
 
 const TEMPERATURE_PROPERTY_ID: &str = "temperature";
@@ -47,6 +47,7 @@ impl UiState {
             let (r, g, b) = if let Some((device_id, node_id, node)) = nodes.get(i) {
                 let selected =
                     device_id == &self.selected_device_id && node_id == &self.selected_node_id;
+                trace!("Showing node {:?}", node);
                 colour_for_node(node, selected)
             } else {
                 (0, 0, 0)

--- a/applehat/src/ui.rs
+++ b/applehat/src/ui.rs
@@ -97,6 +97,15 @@ impl UiState {
     fn button_pressed(&mut self, button_index: usize) {
         debug!("Button {} pressed.", button_index);
     }
+
+    fn update_button_state(&mut self, new_state: [bool; 3]) {
+        for i in 0..3 {
+            if new_state[i] && !self.button_state[i] {
+                self.button_pressed(i);
+            }
+        }
+        self.button_state = new_state;
+    }
 }
 
 pub fn spawn_button_poll_loop(
@@ -105,21 +114,12 @@ pub fn spawn_button_poll_loop(
 ) -> JoinHandle<()> {
     task::spawn(async move {
         loop {
-            let new_states = [
+            let new_state = [
                 buttons.a.is_pressed(),
                 buttons.b.is_pressed(),
                 buttons.c.is_pressed(),
             ];
-
-            {
-                let mut ui_state = ui_state.lock().unwrap();
-                for i in 0..3 {
-                    if new_states[i] && !ui_state.button_state[i] {
-                        ui_state.button_pressed(i);
-                    }
-                }
-                ui_state.button_state = new_states;
-            }
+            ui_state.lock().unwrap().update_button_state(new_state);
 
             sleep(BUTTON_POLL_PERIOD).await;
         }

--- a/applehat/src/ui.rs
+++ b/applehat/src/ui.rs
@@ -6,7 +6,7 @@ use rainbow_hat_rs::{alphanum4::Alphanum4, apa102::APA102};
 
 const TEMPERATURE_PROPERTY_ID: &str = "temperature";
 const HUMIDITY_PROPERTY_ID: &str = "humidity";
-const PIXEL_BRIGHTNESS: f32 = 0.4;
+const PIXEL_BRIGHTNESS: f32 = 0.2;
 
 #[derive(Debug)]
 pub struct UiState {
@@ -169,7 +169,7 @@ fn colour_for_node(node: &Node, selected: bool) -> (u8, u8, u8) {
     (
         scale_to_u8(temperature, 0.0, 40.0),
         (humidity * 255 / 100) as u8,
-        if selected { 255 } else { 0 },
+        if selected { 128 } else { 0 },
     )
 }
 

--- a/applehat/src/ui.rs
+++ b/applehat/src/ui.rs
@@ -51,6 +51,13 @@ impl UiState {
             error!("Error setting RGB LEDs: {}", e);
         }
 
+        if self.selected_device_id.is_none() || self.selected_node_id.is_none() {
+            if let Some((device_id, node_id, _)) = nodes.get(0) {
+                self.selected_device_id = Some(device_id.to_string());
+                self.selected_node_id = Some(node_id.to_string());
+            }
+        }
+
         if let (Some(selected_device_id), Some(selected_node_id)) =
             (&self.selected_device_id, &self.selected_node_id)
         {

--- a/applehat/src/ui.rs
+++ b/applehat/src/ui.rs
@@ -1,6 +1,10 @@
 use homie_controller::{Datatype, Device, HomieController, Node, Property, State};
 use log::{debug, error, trace};
-use rainbow_hat_rs::{alphanum4::Alphanum4, apa102::APA102, touch::Buttons};
+use rainbow_hat_rs::{
+    alphanum4::Alphanum4,
+    apa102::{APA102, NUM_PIXELS},
+    touch::Buttons,
+};
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex},
@@ -50,7 +54,7 @@ impl UiState {
 
         // Show first 7 nodes on RGB LEDs.
         let nodes = find_nodes(&devices);
-        for i in 0..7 {
+        for i in 0..NUM_PIXELS {
             let (r, g, b) = if let Some((device_id, node_id, node)) = nodes.get(i) {
                 let selected = Some(*device_id) == self.selected_device_id.as_deref()
                     && Some(*node_id) == self.selected_node_id.as_deref();
@@ -60,7 +64,7 @@ impl UiState {
                 (0, 0, 0)
             };
             // TODO: Fix set_pixel brightness to work.
-            self.pixels.pixels[i] = [r, g, b, self.selected_brightness as u8];
+            self.pixels.pixels[NUM_PIXELS - 1 - i] = [r, g, b, self.selected_brightness as u8];
             //self.pixels.set_pixel(i, r, g, b, PIXEL_BRIGHTNESS);
         }
         if let Err(e) = self.pixels.show() {

--- a/applehat/src/ui.rs
+++ b/applehat/src/ui.rs
@@ -274,7 +274,7 @@ fn colour_for_node(node: &Node, selected: bool) -> (u8, u8, u8) {
 
     (
         scale_to_u8(temperature, 0.0, 40.0),
-        (humidity * 255 / 100) as u8,
+        scale_to_u8(humidity as f64, 30.0, 100.0),
         if selected { 128 } else { 0 },
     )
 }

--- a/applehat/src/ui.rs
+++ b/applehat/src/ui.rs
@@ -13,6 +13,7 @@ use tokio::{
 
 const TEMPERATURE_PROPERTY_ID: &str = "temperature";
 const HUMIDITY_PROPERTY_ID: &str = "humidity";
+const PROPERTY_IDS: [&str; 2] = [TEMPERATURE_PROPERTY_ID, HUMIDITY_PROPERTY_ID];
 const PIXEL_BRIGHTNESS: f32 = 0.2;
 const BUTTON_POLL_PERIOD: Duration = Duration::from_millis(100);
 
@@ -33,7 +34,7 @@ impl UiState {
             pixels,
             selected_device_id: None,
             selected_node_id: None,
-            selected_property_id: "temperature".to_string(),
+            selected_property_id: TEMPERATURE_PROPERTY_ID.to_string(),
             button_state: Default::default(),
         }
     }
@@ -96,6 +97,21 @@ impl UiState {
 
     fn button_pressed(&mut self, button_index: usize) {
         debug!("Button {} pressed.", button_index);
+        match button_index {
+            0 => {
+                // Select next node.
+            }
+            1 => {
+                // Select next property.
+                let current_index = PROPERTY_IDS
+                    .iter()
+                    .position(|x| x == &self.selected_property_id)
+                    .unwrap_or(0);
+                self.selected_property_id =
+                    PROPERTY_IDS[(current_index + 1) % PROPERTY_IDS.len()].to_string();
+            }
+            _ => {}
+        }
     }
 
     fn update_button_state(&mut self, new_state: [bool; 3]) {

--- a/applehat/src/ui.rs
+++ b/applehat/src/ui.rs
@@ -110,6 +110,23 @@ impl UiState {
         match button_index {
             0 => {
                 // Select next node.
+                let devices = self.controller.devices();
+                let nodes = find_nodes(&devices);
+                if !nodes.is_empty() {
+                    let new_index = if let Some(selected_node_id) = &self.selected_node_id {
+                        if let Some(current_index) = nodes
+                            .iter()
+                            .position(|(_, node_id, _)| node_id == selected_node_id)
+                        {
+                            (current_index + 1) % nodes.len()
+                        } else {
+                            0
+                        }
+                    } else {
+                        0
+                    };
+                    self.selected_node_id = Some(nodes[new_index].1.to_string());
+                }
             }
             1 => {
                 // Select next property.

--- a/applehat/src/ui.rs
+++ b/applehat/src/ui.rs
@@ -51,7 +51,9 @@ impl UiState {
             } else {
                 (0, 0, 0)
             };
-            self.pixels.set_pixel(i, r, g, b, PIXEL_BRIGHTNESS);
+            // TODO: Fix set_pixel brightness to work.
+            self.pixels.pixels[i] = [r, g, b, (PIXEL_BRIGHTNESS * 31.0) as u8];
+            //self.pixels.set_pixel(i, r, g, b, PIXEL_BRIGHTNESS);
         }
         if let Err(e) = self.pixels.show() {
             error!("Error setting RGB LEDs: {}", e);

--- a/applehat/src/ui.rs
+++ b/applehat/src/ui.rs
@@ -6,6 +6,7 @@ use rainbow_hat_rs::{alphanum4::Alphanum4, apa102::APA102};
 
 const TEMPERATURE_PROPERTY_ID: &str = "temperature";
 const HUMIDITY_PROPERTY_ID: &str = "humidity";
+const PIXEL_BRIGHTNESS: f32 = 0.4;
 
 #[derive(Debug)]
 pub struct UiState {
@@ -50,7 +51,7 @@ impl UiState {
             } else {
                 (0, 0, 0)
             };
-            self.pixels.set_pixel(i, r, g, b, 1.0);
+            self.pixels.set_pixel(i, r, g, b, PIXEL_BRIGHTNESS);
         }
         if let Err(e) = self.pixels.show() {
             error!("Error setting RGB LEDs: {}", e);

--- a/package.sh
+++ b/package.sh
@@ -4,13 +4,14 @@
 
 set -euo pipefail
 
+CRATE=${CRATE:-"mijia-homie"}
 TARGET=${TARGET:-}
 
 if [ -z "$TARGET" ]; then
-  cd mijia-homie
+  cd "$CRATE"
   cargo deb
 else
-  cross build --release --target "$TARGET" --bin mijia-homie
-  cd mijia-homie
+  cross build --release --target "$TARGET" --bin "$CRATE"
+  cd "$CRATE"
   cargo deb --target "$TARGET" --no-build
 fi


### PR DESCRIPTION
This is a new binary crate that uses `homie-controller` to find all temperature and humidity sensors and display them on a hat attached to a Raspberry Pi. Up to 7 sensor values are displayed graphically on the RGB LEDs, and a single temperature or humidity value on the alphanumeric display. The touch 'buttons' can be used to switch between sensors, switch between temperature and humidty, and adjust the brightness (or turn the display off entirely).