### PR TITLE
Use btsensor in mijia-homie.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,6 +1350,7 @@ name = "mijia-homie"
 version = "0.2.6"
 dependencies = [
  "backoff",
+ "btsensor",
  "color-backtrace",
  "eyre",
  "futures",

--- a/mijia-homie/CHANGELOG.md
+++ b/mijia-homie/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### New features
+
+- Added support for sensors with third-party firmware advertising in atc1441 format, pvvx custom
+  format, or BTHome (v1 or v2, unencrypted).
+
 ## 0.2.6
 
 ### Other changes

--- a/mijia-homie/Cargo.toml
+++ b/mijia-homie/Cargo.toml
@@ -24,6 +24,7 @@ path = "src/mijia-names.rs"
 
 [dependencies]
 backoff = { version = "0.4.0", features = ["tokio"] }
+btsensor = { version = "0.1.0", path = "../btsensor" }
 color-backtrace = "0.6.0"
 eyre = "0.6.8"
 futures = "0.3.27"

--- a/mijia-homie/src/main.rs
+++ b/mijia-homie/src/main.rs
@@ -12,7 +12,7 @@ use futures::stream::StreamExt;
 use futures::TryFutureExt;
 use homie_device::{HomieDevice, Node, Property};
 use itertools::Itertools;
-use log::info;
+use log::{debug, info};
 use mijia::bluetooth::{
     BluetoothError, BluetoothEvent, BluetoothSession, DeviceEvent, DeviceId, MacAddress,
 };
@@ -270,7 +270,12 @@ impl Sensor {
                                             .await?;
                                     }
                                 }
-                                _ => {}
+                                _ => {
+                                    debug!(
+                                        "Skipping unexpected BTHome v1 element {} on {} ({})",
+                                        element, self.mac_address, self.name
+                                    );
+                                }
                             }
                         }
                     }
@@ -306,7 +311,12 @@ impl Sensor {
                                     )
                                     .await?;
                             }
-                            _ => {}
+                            _ => {
+                                debug!(
+                                    "Skipping unexpected BTHome v2 element {} on {} ({})",
+                                    element, self.mac_address, self.name
+                                );
+                            }
                         }
                     }
                 }

--- a/mijia-homie/src/main.rs
+++ b/mijia-homie/src/main.rs
@@ -270,6 +270,7 @@ impl Sensor {
                                             .await?;
                                     }
                                 }
+                                bthome::v1::Property::PacketId => {}
                                 _ => {
                                     debug!(
                                         "Skipping unexpected BTHome v1 element {} on {} ({})",

--- a/mijia/CHANGELOG.md
+++ b/mijia/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### New features
+
+- Exposed `MijiaEvent::from`, for converting a `bluez-async` `BluetoothEvent` into a `MijiaEvent`.
+  This can be useful if you want to handle other bluetooth events directly as well as Mijia events.
+
 ## 0.7.0
 
 ### Breaking changes

--- a/mijia/src/lib.rs
+++ b/mijia/src/lib.rs
@@ -96,7 +96,7 @@ pub enum MijiaEvent {
 }
 
 impl MijiaEvent {
-    async fn from(event: BluetoothEvent, session: BluetoothSession) -> Option<Self> {
+    pub async fn from(event: BluetoothEvent, session: BluetoothSession) -> Option<Self> {
         match event {
             BluetoothEvent::Characteristic {
                 id: characteristic,


### PR DESCRIPTION
For now the Homie node properties are still hardcoded for BTHome sensors, it assumes they have temperature, humidity and battery percentage, and nothing else. It would be nice to discover properties automatically, but there is no immediate need for that. Only sensors with names configured in `sensor-names.toml` will be included.