### PR TITLE
Fix cross builds.

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -2,7 +2,7 @@
 # Based on https://www.collabora.com/news-and-blog/blog/2020/06/23/cross-building-rust-gstreamer-plugins-for-the-raspberry-pi/
 # but with `RUN apt-get install -y libdbus-1-dev:armhf` thrown in to get the dependency we need.
 # This image has been pushed to dockerhub.
-image = "ghcr.io/qwandor/cross-dbus-debian-buster-armv7:0.2.1-1"
+image = "ghcr.io/qwandor/cross-dbus-debian-trixie-armv7:0.2.1-2"
 
 # Once https://github.com/rust-embedded/cross/pull/446 gets somewhere, you
 # will be able to use `context` and `dockerfile` to achieve the same result.
@@ -10,22 +10,22 @@ image = "ghcr.io/qwandor/cross-dbus-debian-buster-armv7:0.2.1-1"
 # cargo install --git=https://github.com/alsuren/cross --branch=docker-build-context
 # and then comment out `image`, above and uncomment the following two lines:
 # context = "./docker"
-# dockerfile = "./docker/Dockerfile.debian-buster-armv7"
+# dockerfile = "./docker/Dockerfile.debian-trixie-armv7"
 
 [target.arm-unknown-linux-gnueabi]
-image = "ghcr.io/qwandor/cross-dbus-debian-buster-armv6:0.2.1-1"
+image = "ghcr.io/qwandor/cross-dbus-debian-trixie-armv6:0.2.1-2"
 
 # context = "./docker"
-# dockerfile = "./docker/Dockerfile.debian-buster-armv6"
+# dockerfile = "./docker/Dockerfile.debian-trixie-armv6"
 
 [target.aarch64-unknown-linux-gnu]
-image = "ghcr.io/qwandor/cross-dbus-debian-buster-aarch64:0.2.1-1"
+image = "ghcr.io/qwandor/cross-dbus-debian-trixie-aarch64:0.2.1-2"
 
 # context = "./docker"
-# dockerfile = "./docker/Dockerfile.debian-buster-aarch64"
+# dockerfile = "./docker/Dockerfile.debian-trixie-aarch64"
 
 [target.x86_64-unknown-linux-gnu]
-image = "ghcr.io/qwandor/cross-dbus-debian-buster-x86_64:0.2.1-1"
+image = "ghcr.io/qwandor/cross-dbus-debian-trixie-x86_64:0.2.1-2"
 
 # context = "./docker"
-# dockerfile = "./docker/Dockerfile.debian-buster-x86_64"
+# dockerfile = "./docker/Dockerfile.debian-trixie-x86_64"

--- a/docker/Dockerfile.debian-trixie-aarch64
+++ b/docker/Dockerfile.debian-trixie-aarch64
@@ -1,7 +1,7 @@
 # Built from https://github.com/qwandor/cross/blob/context/docker/Dockerfile.context
 FROM ghcr.io/qwandor/cross-context:0.2.1 as context
 
-FROM debian:buster
+FROM debian:trixie
 
 COPY --from=context common.sh lib.sh /
 RUN /common.sh
@@ -9,12 +9,10 @@ RUN /common.sh
 COPY --from=context cmake.sh /
 RUN /cmake.sh
 
-COPY --from=context xargo.sh /
-RUN /xargo.sh
-
-RUN apt-get install --assume-yes --no-install-recommends \
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
 	g++-aarch64-linux-gnu \
-	libc6-dev-arm64-cross
+	libc6-dev-arm64-cross \
+	libclang-dev
 
 RUN dpkg --add-architecture arm64 && \
 	apt-get update && \

--- a/docker/Dockerfile.debian-trixie-armv6
+++ b/docker/Dockerfile.debian-trixie-armv6
@@ -5,7 +5,7 @@ FROM ghcr.io/qwandor/cross-context:0.2.1 as context
 # Raspberry Pi 1 (A, B, A+, B+, Zero, Zero W) is supported by armel for Debian
 # More details here https://wiki.debian.org/RaspberryPi#Raspberry_Pi_1_.28A.2C_B.2C_A.2B-.2C_B.2B-.2C_Zero.2C_Zero_W.29
 
-FROM debian:buster
+FROM debian:trixie
 
 COPY --from=context common.sh lib.sh /
 RUN /common.sh
@@ -13,16 +13,18 @@ RUN /common.sh
 COPY --from=context cmake.sh /
 RUN /cmake.sh
 
-COPY --from=context xargo.sh /
-RUN /xargo.sh
-
-RUN apt-get install --assume-yes --no-install-recommends \
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
 	g++-arm-linux-gnueabi \
-	libc6-dev-armel-cross
+	libc6-dev-armel-cross \
+	libclang-dev
 
 RUN dpkg --add-architecture armel && \
 	apt-get update && \
 	apt-get install -y libdbus-1-dev:armel
+
+RUN curl --retry 3 -sSfL https://sh.rustup.rs | sh -s -- -y --profile minimal
+
+RUN $HOME/.cargo/bin/cargo install --force --locked bindgen-cli --version 0.72.1 --root /usr/local
 
 ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABI_LINKER=arm-linux-gnueabi-gcc \
 	CC_arm_unknown_linux_gnueabi=arm-linux-gnueabi-gcc \

--- a/docker/Dockerfile.debian-trixie-armv7
+++ b/docker/Dockerfile.debian-trixie-armv7
@@ -1,7 +1,7 @@
 # Built from https://github.com/qwandor/cross/blob/context/docker/Dockerfile.context
 FROM ghcr.io/qwandor/cross-context:0.2.1 as context
 
-FROM debian:buster
+FROM debian:trixie
 
 COPY --from=context common.sh lib.sh /
 RUN /common.sh
@@ -9,16 +9,18 @@ RUN /common.sh
 COPY --from=context cmake.sh /
 RUN /cmake.sh
 
-COPY --from=context xargo.sh /
-RUN /xargo.sh
-
-RUN apt-get install --assume-yes --no-install-recommends \
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
 	g++-arm-linux-gnueabihf \
-	libc6-dev-armhf-cross
+	libc6-dev-armhf-cross \
+	libclang-dev
 
 RUN dpkg --add-architecture armhf && \
 	apt-get update && \
 	apt-get install -y libdbus-1-dev:armhf
+
+RUN curl --retry 3 -sSfL https://sh.rustup.rs | sh -s -- -y --profile minimal
+
+RUN $HOME/.cargo/bin/cargo install --force --locked bindgen-cli --version 0.72.1 --root /usr/local
 
 ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
 	CC_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-gcc \

--- a/docker/Dockerfile.debian-trixie-x86_64
+++ b/docker/Dockerfile.debian-trixie-x86_64
@@ -1,16 +1,13 @@
 # Built from https://github.com/qwandor/cross/blob/context/docker/Dockerfile.context
 FROM ghcr.io/qwandor/cross-context:0.2.1 as context
 
-FROM debian:buster
+FROM debian:trixie
 
 COPY --from=context common.sh lib.sh /
 RUN /common.sh
 
 COPY --from=context cmake.sh /
 RUN /cmake.sh
-
-COPY --from=context xargo.sh /
-RUN /xargo.sh
 
 RUN apt-get update && \
 	apt-get install -y libdbus-1-dev

--- a/docker/update.sh
+++ b/docker/update.sh
@@ -2,17 +2,18 @@
 
 set -euo pipefail
 
-VERSION=0.2.1-1
+VERSION=0.2.1-2
 
-docker build ./docker -f docker/Dockerfile.debian-buster-aarch64 \
-    -t ghcr.io/qwandor/cross-dbus-debian-buster-aarch64:$VERSION
-docker build ./docker -f docker/Dockerfile.debian-buster-armv7 \
-    -t ghcr.io/qwandor/cross-dbus-debian-buster-armv7:$VERSION
-docker build ./docker -f docker/Dockerfile.debian-buster-armv6 \
-    -t ghcr.io/qwandor/cross-dbus-debian-buster-armv6:$VERSION
-docker build ./docker -f docker/Dockerfile.debian-buster-x86_64 \
-    -t ghcr.io/qwandor/cross-dbus-debian-buster-x86_64:$VERSION
+docker build ./docker -f docker/Dockerfile.debian-trixie-aarch64 \
+    -t ghcr.io/qwandor/cross-dbus-debian-trixie-aarch64:$VERSION
+docker build ./docker -f docker/Dockerfile.debian-trixie-armv7 \
+    -t ghcr.io/qwandor/cross-dbus-debian-trixie-armv7:$VERSION
+docker build ./docker -f docker/Dockerfile.debian-trixie-armv6 \
+    -t ghcr.io/qwandor/cross-dbus-debian-trixie-armv6:$VERSION
+docker build ./docker -f docker/Dockerfile.debian-trixie-x86_64 \
+    -t ghcr.io/qwandor/cross-dbus-debian-trixie-x86_64:$VERSION
 
-docker push ghcr.io/qwandor/cross-dbus-debian-buster-aarch64:$VERSION
-docker push ghcr.io/qwandor/cross-dbus-debian-buster-armv7:$VERSION
-docker push ghcr.io/qwandor/cross-dbus-debian-buster-x86_64:$VERSION
+docker push ghcr.io/qwandor/cross-dbus-debian-trixie-aarch64:$VERSION
+docker push ghcr.io/qwandor/cross-dbus-debian-trixie-armv7:$VERSION
+docker push ghcr.io/qwandor/cross-dbus-debian-trixie-armv6:$VERSION
+docker push ghcr.io/qwandor/cross-dbus-debian-trixie-x86_64:$VERSION


### PR DESCRIPTION
aws-lc-sys was failing to build in cross for some architectures due to missing bindgen-cli. Adding it to the Docker containers required updating from Debian buster to trixie, as buster is no longer supported.