### PR TITLE
Various fixes to Raspberry Pi install script

### DIFF
--- a/install-rpi.sh
+++ b/install-rpi.sh
@@ -157,10 +157,9 @@ if [[ "$STEP" == 7 ]]; then
 fi
 
 if [[ "$STEP" == 8 ]]; then
-    curl -L https://homiers.jfrog.io/artifactory/api/security/keypair/public/repositories/homie-rs | ssh "${FINAL_SSH}" sudo apt-key add -
-    echo "deb https://homiers.jfrog.io/artifactory/homie-rs stable main" | ssh "${FINAL_SSH}" sudo tee /etc/apt/sources.list.d/homie-rs.list
+    # TODO: Set up a repository and install mijia-homie somehow.
     ssh "${FINAL_SSH}" sudo apt update
-    ssh "${FINAL_SSH}" sudo apt install mijia-homie
+    #ssh "${FINAL_SSH}" sudo apt install mijia-homie
 
     inc_step
 fi

--- a/install-rpi.sh
+++ b/install-rpi.sh
@@ -190,8 +190,8 @@ fi
 if [[ "$STEP" == 12 ]]; then
     VERSION_CODENAME=$(ssh "${FINAL_SSH}" grep VERSION_CODENAME /etc/os-release | sed s/VERSION_CODENAME=//)
 
-    curl -s https://repos.influxdata.com/influxdb.key | ssh "${FINAL_SSH}" sudo apt-key add -
-    echo "deb https://repos.influxdata.com/debian ${VERSION_CODENAME} stable" | ssh "${FINAL_SSH}" sudo tee /etc/apt/sources.list.d/influxdb.list
+    curl -s https://repos.influxdata.com/influxdata-archive.key | gpg --dearmor | ssh "${FINAL_SSH}" sudo tee /etc/apt/keyrings/influxdata-archive.gpg > /dev/null
+    echo "deb [signed-by=/etc/apt/keyrings/influxdata-archive.gpg] https://repos.influxdata.com/debian ${VERSION_CODENAME} main" | ssh "${FINAL_SSH}" sudo tee /etc/apt/sources.list.d/influxdata.list
 
     ssh "${FINAL_SSH}" sudo apt update
     ssh "${FINAL_SSH}" sudo apt install telegraf


### PR DESCRIPTION
Removed mijia-homie install step for now, as the repository no longer exists.

Updated URLs for Telegraf install. Also updated not to use apt-key, which is deprecated.